### PR TITLE
KVSTORE-3325 Require IMDSv2 for instance metadata, KVSTORE-3347 , KVSTORE-3351, KVSTORE-3350, KVSTORE-3345

### DIFF
--- a/Documentation/tutorials/tables.md
+++ b/Documentation/tutorials/tables.md
@@ -1226,8 +1226,9 @@ include throttling exceptions as well as other exceptions where a resource is
 temporarily anavailable.  Some other subclasses of
 [NoSQLException](xref:Oracle.NoSQL.SDK.NoSQLException) may also be
 retryable depending on the conditions under which the exception occurred.  See
-API documentation for details.  In addition, network-related errors are
-retryable because most network conditions are temporary.
+API documentation for details.  In addition, network-related errors may be
+retryable for operations that are safe to replay, because most network
+conditions are temporary.
 * Exceptions that should not be retried because they will still fail after
 retry.  They include exceptions such as
 [TableNotFoundException](xref:Oracle.NoSQL.SDK.TableNotFoundException),

--- a/Oracle.NoSQL.SDK.Samples/BasicExample/BasicExample.csproj
+++ b/Oracle.NoSQL.SDK.Samples/BasicExample/BasicExample.csproj
@@ -2,9 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-	<RollForward>Major</RollForward>
-	<CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Oracle.NoSQL.SDK.Samples</RootNamespace>
   </PropertyGroup>
 

--- a/Oracle.NoSQL.SDK.Samples/BasicExample/Program.cs
+++ b/Oracle.NoSQL.SDK.Samples/BasicExample/Program.cs
@@ -46,18 +46,16 @@ namespace Oracle.NoSQL.SDK.Samples
     //
     // Run the example as:
     //
-    // dotnet run -f <target framework> -- <config file>
+    // dotnet run -- <config file>
     //
     // where:
-    //   - <target framework> is target framework moniker, supported values
-    //     are netcoreapp3.1 and net5.0
     //   - <config file> is the JSON config file created as described above
     // ------------------------------------------------------------------------
 
     public class Program
     {
         private const string Usage =
-            "Usage: dotnet run -f <target framework> [-- <config file>]";
+            "Usage: dotnet run [-- <config file>]";
         private const string TableName = "BasicExample";
 
         // <Main>

--- a/Oracle.NoSQL.SDK.Samples/QueryExample/Program.cs
+++ b/Oracle.NoSQL.SDK.Samples/QueryExample/Program.cs
@@ -48,18 +48,16 @@ namespace Oracle.NoSQL.SDK.Samples
     //
     // Run the example as:
     //
-    // dotnet run -f <target framework> -- <config file>
+    // dotnet run -- <config file>
     //
     // where:
-    //   - <target framework> is target framework moniker, supported values
-    //     are netcoreapp3.1 and net5.0
     //   - <config file> is the JSON config file created as described above
     // ------------------------------------------------------------------------
 
     public class Program
     {
         private const string Usage =
-            "Usage: dotnet run -f <target framework> [-- <config file>]";
+            "Usage: dotnet run [-- <config file>]";
         private const string TableName = "users";
 
         private static readonly JsonOutputOptions JsonOptions =

--- a/Oracle.NoSQL.SDK.Samples/QueryExample/QueryExample.csproj
+++ b/Oracle.NoSQL.SDK.Samples/QueryExample/QueryExample.csproj
@@ -2,9 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-	<RollForward>Major</RollForward>
-    <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Oracle.NoSQL.SDK.Samples</RootNamespace>
   </PropertyGroup>
 

--- a/Oracle.NoSQL.SDK/src/Auth/IAM/IAMAuthorizationProvider.Internal.cs
+++ b/Oracle.NoSQL.SDK/src/Auth/IAM/IAMAuthorizationProvider.Internal.cs
@@ -145,6 +145,9 @@ namespace Oracle.NoSQL.SDK
             }
         }
 
+        private bool HasDynamicDelegationToken =>
+            DelegationTokenProvider != null || DelegationTokenFile != null;
+
         private async Task<string> LoadDelegationToken(
             CancellationToken cancellationToken)
         {
@@ -234,7 +237,8 @@ namespace Oracle.NoSQL.SDK
 
         private async Task<SignatureDetails> CreateSignatureDetailsAsync(
             Request request, HttpRequestMessage message,
-            bool forceProfileRefresh, CancellationToken cancellationToken)
+            bool forceProfileRefresh, CancellationToken cancellationToken,
+            string currentDelegationToken = null)
         {
             AuthenticationProfile profile;
 
@@ -252,12 +256,17 @@ namespace Oracle.NoSQL.SDK
                 providerAsyncLock.Release();
             }
 
-            // If there is no DelegationTokenProvider or DelegationTokenFile,
-            // delegationToken could have been initialized in the constructor.
-            var currentDelegationToken =
-                DelegationTokenProvider != null || DelegationTokenFile != null
-                    ? await LoadDelegationToken(cancellationToken)
-                    : DelegationToken;
+            if (!HasDynamicDelegationToken)
+            {
+                // If there is no DelegationTokenProvider or DelegationTokenFile,
+                // delegationToken could have been initialized in the constructor.
+                currentDelegationToken = DelegationToken;
+            }
+            else if (currentDelegationToken == null)
+            {
+                currentDelegationToken =
+                    await LoadDelegationToken(cancellationToken);
+            }
 
             ContentSigningInfo contentSigningInfo = null;
             if (request?.NeedsContentSigned ?? false)
@@ -375,6 +384,11 @@ namespace Oracle.NoSQL.SDK
             SignatureDetails signatureDetails) =>
             signatureDetails == null || DateTime.UtcNow >
             signatureDetails.Time + CacheDuration;
+
+        private static bool DelegationTokenMatches(
+            SignatureDetails signatureDetails,
+            string currentDelegationToken) =>
+            signatureDetails?.DelegationToken == currentDelegationToken;
 
         /// <summary>
         /// Validates and configures the authorization provider.

--- a/Oracle.NoSQL.SDK/src/Auth/IAM/IAMAuthorizationProvider.cs
+++ b/Oracle.NoSQL.SDK/src/Auth/IAM/IAMAuthorizationProvider.cs
@@ -122,7 +122,9 @@ namespace Oracle.NoSQL.SDK
         /// </para>
         /// <para>
         /// The delegation token provider delegate is called to obtain the
-        /// delegation token each time the request signature is renewed.
+        /// delegation token when authorizing requests.  If a cached request
+        /// signature is available, the token returned by the delegate must
+        /// match the cached token before the signature is reused.
         /// </para>
         /// </remarks>
         /// <value>
@@ -147,9 +149,10 @@ namespace Oracle.NoSQL.SDK
         /// user.
         /// </para>
         /// <para>
-        /// The delegation token file is read each time the request signature
-        /// is renewed. You may also use the property in JSON configuration
-        /// file (see examples).
+        /// The delegation token file is read when authorizing requests.  If a
+        /// cached request signature is available, the token read from the file
+        /// must match the cached token before the signature is reused. You may
+        /// also use the property in JSON configuration file (see examples).
         /// </para>
         /// </remarks>
         /// <value>
@@ -480,8 +483,8 @@ namespace Oracle.NoSQL.SDK
         /// <remarks>
         /// The delegation token allows the instance to assume the privileges
         /// of the user for which the token was created.  The delegation token
-        /// provider delegate will be used to obtain the delegation token each
-        /// time the request signature is renewed.
+        /// provider delegate will be used to obtain the delegation token when
+        /// authorizing requests.
         /// </remarks>
         /// <param name="delegationTokenProvider">The delegation token
         /// provider delegate.</param>
@@ -511,8 +514,8 @@ namespace Oracle.NoSQL.SDK
         /// <remarks>
         /// The delegation token allows the instance to assume the privileges
         /// of the user for which the token was created.  The delegation token
-        /// file will be read to obtain the delegation token each time the
-        /// request signature is renewed.
+        /// file will be read to obtain the delegation token when authorizing
+        /// requests.
         /// </remarks>
         /// <param name="delegationTokenFile">Path to the delegation token
         /// file.</param>
@@ -697,19 +700,29 @@ namespace Oracle.NoSQL.SDK
             var isInvalidAuth =
                 request.LastException is InvalidAuthorizationException;
             var contentSigned = request.NeedsContentSigned;
+            var hasDynamicDelegationToken = HasDynamicDelegationToken;
+            var currentDelegationToken = hasDynamicDelegationToken
+                ? await LoadDelegationToken(cancellationToken)
+                : null;
+            var cachedSignatureDetails = CachedSignatureDetails;
             
             SignatureDetails signatureDetails;
             if (isInvalidAuth || contentSigned ||
                 !profileProvider.IsProfileValid ||
-                NeedSignatureRefresh(CachedSignatureDetails))
+                NeedSignatureRefresh(cachedSignatureDetails) ||
+                (hasDynamicDelegationToken &&
+                 !DelegationTokenMatches(cachedSignatureDetails,
+                     currentDelegationToken)))
             {
                 signatureDetails = await CreateSignatureDetailsAsync(
-                    request, message, isInvalidAuth, cancellationToken);
+                    request, message, isInvalidAuth, cancellationToken,
+                    currentDelegationToken);
 
                 if (!contentSigned)
                 {
                     CachedSignatureDetails = signatureDetails;
-                    if (RefreshAhead != TimeSpan.Zero)
+                    if (!hasDynamicDelegationToken &&
+                        RefreshAhead != TimeSpan.Zero)
                     {
                         ScheduleRenew();
                     }
@@ -717,7 +730,7 @@ namespace Oracle.NoSQL.SDK
             }
             else
             {
-                signatureDetails = CachedSignatureDetails;
+                signatureDetails = cachedSignatureDetails;
             }
 
             message.Headers.Add(Authorization,

--- a/Oracle.NoSQL.SDK/src/Auth/IAM/InstanceMetadataClient.cs
+++ b/Oracle.NoSQL.SDK/src/Auth/IAM/InstanceMetadataClient.cs
@@ -8,7 +8,6 @@
 namespace Oracle.NoSQL.SDK
 {
     using System;
-    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -33,14 +32,13 @@ namespace Oracle.NoSQL.SDK
     /// </remarks>
     public sealed class InstanceMetadataClient : IDisposable
     {
-        // Instance metadata service base URL
+        // OCI instance metadata service v2 base URL. IMDS is exposed by OCI
+        // as a link-local HTTP endpoint and requires Authorization: Bearer
+        // Oracle for v2 requests.
         private const string MetadataServiceBaseUrl =
             "http://169.254.169.254/opc/v2/";
 
-        private const string FallbackMetadataServiceUrl =
-            "http://169.254.169.254/opc/v1/";
-
-        // The authorization header need to send to metadata service since V2
+        // The authorization header to send to metadata service v2.
         private const string AuthorizationHeaderValue = "Bearer Oracle";
 
         private readonly AuthHttpClient httpClient;
@@ -94,11 +92,9 @@ namespace Oracle.NoSQL.SDK
         internal async Task<string> GetValueAsync(string path,
             CancellationToken cancellationToken)
         {
-            var checkFallback = false;
             if (metadataUrl == null)
             {
                 metadataUrl = MetadataServiceBaseUrl;
-                checkFallback = true;
             }
 
             try
@@ -107,25 +103,6 @@ namespace Oracle.NoSQL.SDK
             }
             catch (Exception ex)
             {
-                if (checkFallback && ex is ServiceResponseException srex &&
-                    srex.StatusCode == HttpStatusCode.NotFound)
-                {
-                    metadataUrl = FallbackMetadataServiceUrl;
-                    try
-                    {
-                        return await GetValueInternalAsync(path,
-                            cancellationToken);
-                    }
-                    catch (Exception ex2)
-                    {
-                        throw new AuthorizationException(
-                            $"Unable to get resource {path} from instance " +
-                            $"metadata {MetadataServiceBaseUrl} or " +
-                            $"fall back to {FallbackMetadataServiceUrl}, " +
-                            $"error: {ex2.Message}", ex2);
-                    }
-                }
-
                 throw new AuthorizationException(
                     $"Unable to get resource {path} from instance metadata " +
                     $"{metadataUrl}, error: {ex.Message}", ex);

--- a/Oracle.NoSQL.SDK/src/Auth/IAM/Utils.cs
+++ b/Oracle.NoSQL.SDK/src/Auth/IAM/Utils.cs
@@ -59,7 +59,7 @@ namespace Oracle.NoSQL.SDK {
         }
 
         internal static X509Certificate2 GetCertificateFromPEM(string pem) =>
-            new X509Certificate2(Encoding.UTF8.GetBytes(pem));
+            X509Certificate2.CreateFromPem(pem);
 
         // Taken from C# OCI SDK
         internal static string GetTenantIdFromInstanceCertificate(

--- a/Oracle.NoSQL.SDK/src/Exceptions/NoSQLException.cs
+++ b/Oracle.NoSQL.SDK/src/Exceptions/NoSQLException.cs
@@ -119,7 +119,8 @@ namespace Oracle.NoSQL.SDK
         /// For instances of <see cref="NoSQLException"/> the driver will
         /// retry only those that have <see cref="IsRetryable"/> equal
         /// <c>true</c>.  In addition, standard exception types indicating
-        /// a network error will be retried as well.  See
+        /// a network error may be retried for operations that are safe to
+        /// replay.  See
         /// <see cref="IRetryHandler"/> for details.
         /// </para>
         /// <para>

--- a/Oracle.NoSQL.SDK/src/Exceptions/ServiceResponseException.cs
+++ b/Oracle.NoSQL.SDK/src/Exceptions/ServiceResponseException.cs
@@ -52,17 +52,9 @@ namespace Oracle.NoSQL.SDK
     public class ServiceResponseException : NoSQLException
     {
         private static string GetMessage(HttpStatusCode statusCode,
-            string reasonPhrase, string content)
-        {
-            var message = "Unsuccessful HTTP response: " +
-                          $"{(int)statusCode} {reasonPhrase}";
-            if (content != null)
-            {
-                message += $". Error output: {content}";
-            }
-
-            return message;
-        }
+            string reasonPhrase) =>
+            "Unsuccessful HTTP response: " +
+            $"{(int)statusCode} {reasonPhrase}";
 
         /// <summary>
         /// Initializes a new instance of
@@ -105,6 +97,9 @@ namespace Oracle.NoSQL.SDK
         /// <remarks>
         /// The value of <see cref="Exception.Message"/> is generated from
         /// <paramref name="statusCode"/> and <paramref name="reasonPhrase"/>.
+        /// The raw HTTP response body is available via
+        /// <see cref="ResponseMessage"/> and may contain sensitive
+        /// diagnostic content.
         /// </remarks>
         /// <param name="statusCode">HTTP status code.</param>
         /// <param name="reasonPhrase">HTTP status message.</param>
@@ -112,7 +107,7 @@ namespace Oracle.NoSQL.SDK
         /// response.</param>
         public ServiceResponseException(HttpStatusCode statusCode,
             string reasonPhrase, string responseMessage) :
-            base(GetMessage(statusCode, reasonPhrase, responseMessage))
+            base(GetMessage(statusCode, reasonPhrase))
         {
             StatusCode = statusCode;
             StatusMessage = reasonPhrase;
@@ -146,7 +141,8 @@ namespace Oracle.NoSQL.SDK
         /// Gets the service response message.
         /// </summary>
         /// <value>Message sent within the body of the service HTTP response.
-        /// </value>
+        /// This value may contain sensitive diagnostic content and should not
+        /// be logged or displayed unless explicitly intended.</value>
         public string ResponseMessage { get; }
     }
 

--- a/Oracle.NoSQL.SDK/src/IRetryHandler.cs
+++ b/Oracle.NoSQL.SDK/src/IRetryHandler.cs
@@ -35,7 +35,8 @@ namespace Oracle.NoSQL.SDK {
     /// </item>
     /// <item>
     /// <description>
-    /// All network-related errors.  Currently those are instances of
+    /// Network-related errors for operations that are safe to replay.
+    /// Currently those errors are instances of
     /// <see cref="System.Net.Http.HttpRequestException"/>.
     /// </description>
     /// </item>

--- a/Oracle.NoSQL.SDK/src/NoSQLRetryHandler.cs
+++ b/Oracle.NoSQL.SDK/src/NoSQLRetryHandler.cs
@@ -211,10 +211,15 @@ namespace Oracle.NoSQL.SDK {
                 return request.Timeout > ControlOperationBaseDelay;
             }
 
-            if (request.LastException is SecurityInfoNotReadyException ||
-                request.Client.IsRetryableNetworkException(request.LastException))
+            if (request.LastException is SecurityInfoNotReadyException)
             {
                 return true;
+            }
+
+            if (request.Client.IsRetryableNetworkException(
+                    request.LastException))
+            {
+                return request.CanRetryOnNetworkException;
             }
 
             if (request.LastException is InvalidAuthorizationException)

--- a/Oracle.NoSQL.SDK/src/Oracle.NoSQL.SDK.csproj
+++ b/Oracle.NoSQL.SDK/src/Oracle.NoSQL.SDK.csproj
@@ -1,9 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
-	<RollForward>Major</RollForward>
-    <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
     <Company>Oracle Corporation</Company>
     <Product>Oracle NoSQL Database</Product>

--- a/Oracle.NoSQL.SDK/src/Region.cs
+++ b/Oracle.NoSQL.SDK/src/Region.cs
@@ -356,14 +356,14 @@ namespace Oracle.NoSQL.SDK
                 var fields = typeof(Region).GetFields(
                     BindingFlags.Public | BindingFlags.Static);
 
-                foreach (var field in fields)
+                foreach (var regionField in fields)
                 {
-                    if (field.FieldType != typeof(Region))
+                    if (regionField.FieldType != typeof(Region))
                     {
                         continue;
                     }
 
-                    var region = (Region)field.GetValue(null);
+                    var region = (Region)regionField.GetValue(null);
                     Debug.Assert(region != null);
 
                     result.Add(region);

--- a/Oracle.NoSQL.SDK/src/Request/AdminRequest.cs
+++ b/Oracle.NoSQL.SDK/src/Request/AdminRequest.cs
@@ -34,6 +34,8 @@ namespace Oracle.NoSQL.SDK
 
         internal override TimeSpan GetDefaultTimeout() => Config.AdminTimeout;
 
+        internal override bool CanRetryOnNetworkException => false;
+
         internal override void Serialize(IRequestSerializer serializer,
             MemoryStream stream)
         {

--- a/Oracle.NoSQL.SDK/src/Request/DeleteRangeRequest.cs
+++ b/Oracle.NoSQL.SDK/src/Request/DeleteRangeRequest.cs
@@ -50,6 +50,8 @@ namespace Oracle.NoSQL.SDK
 
         internal override bool DoesWrites => true;
 
+        internal override bool CanRetryOnNetworkException => false;
+
         internal override void Validate()
         {
             base.Validate();

--- a/Oracle.NoSQL.SDK/src/Request/QueryRequest.cs
+++ b/Oracle.NoSQL.SDK/src/Request/QueryRequest.cs
@@ -72,6 +72,10 @@ namespace Oracle.NoSQL.SDK
             PreparedStatement != null &&
             PreparedStatement.OperationCode == OperationCodeSelect;
 
+        internal override bool CanRetryOnNetworkException =>
+            PreparedStatement != null &&
+            PreparedStatement.OperationCode == OperationCodeSelect;
+
         internal override string InternalTableName =>
             PreparedStatement?.TableName;
 

--- a/Oracle.NoSQL.SDK/src/Request/Request.cs
+++ b/Oracle.NoSQL.SDK/src/Request/Request.cs
@@ -212,6 +212,10 @@ namespace Oracle.NoSQL.SDK
 
         internal virtual bool ShouldRetry => true;
 
+        // Network exceptions are ambiguous because the service may have
+        // committed the request before the response was lost.
+        internal virtual bool CanRetryOnNetworkException => true;
+
         internal virtual bool SupportsRateLimiting => false;
 
         // Used by rate limiting.

--- a/Oracle.NoSQL.SDK/src/Request/RequestWithTable.cs
+++ b/Oracle.NoSQL.SDK/src/Request/RequestWithTable.cs
@@ -107,6 +107,8 @@ namespace Oracle.NoSQL.SDK
         internal override bool SupportsRateLimiting => true;
 
         internal override bool DoesWrites => true;
+
+        internal override bool CanRetryOnNetworkException => false;
     }
 
     /// <summary>
@@ -131,6 +133,8 @@ namespace Oracle.NoSQL.SDK
 
         internal override TimeSpan GetDefaultTimeout() =>
             Config.TableDDLTimeout;
+
+        internal override bool CanRetryOnNetworkException => false;
 
         internal override void ApplyResult(object result)
         {

--- a/Oracle.NoSQL.SDK/src/Request/WriteManyRequest.cs
+++ b/Oracle.NoSQL.SDK/src/Request/WriteManyRequest.cs
@@ -40,6 +40,8 @@ namespace Oracle.NoSQL.SDK
 
         internal override bool DoesWrites => true;
 
+        internal override bool CanRetryOnNetworkException => false;
+
         internal string TableName { get; }
 
         internal WriteOperationCollection Operations { get; }

--- a/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.SmokeTest/Oracle.NoSQL.SDK.SmokeTest.csproj
+++ b/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.SmokeTest/Oracle.NoSQL.SDK.SmokeTest.csproj
@@ -2,9 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-	<RollForward>Major</RollForward>
-	<CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <ApplicationIcon />
     <StartupObject />

--- a/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/IAM/AuthProviderTests.Positive.cs
+++ b/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/IAM/AuthProviderTests.Positive.cs
@@ -11,6 +11,7 @@ namespace Oracle.NoSQL.SDK.Tests.IAM
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Reflection;
     using System.Threading;
     using System.Threading.Tasks;
     using System.Net.Http;
@@ -186,6 +187,19 @@ namespace Oracle.NoSQL.SDK.Tests.IAM
                 ? GetKeyIdFromToken(iam.SessTokenFileData)
                 : CredentialsKeyId;
 
+        private static void UseTestProfileProvider(
+            IAMAuthorizationProvider provider)
+        {
+            var profileProviderField =
+                typeof(IAMAuthorizationProvider).GetField("profileProvider",
+                    BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(profileProviderField);
+
+            (profileProviderField.GetValue(provider) as IDisposable)?.Dispose();
+            profileProviderField.SetValue(provider,
+                new CredentialsProfileProvider(CredentialsPK));
+        }
+
         private IAMConfigInfo currentIAMConfig;
 
         private void PrepareConfig(IAMConfigInfo iam)
@@ -343,6 +357,151 @@ namespace Oracle.NoSQL.SDK.Tests.IAM
             // +4200 ms, automatic refresh should have happened again
             VerifyAuthLaterDate(message1.Headers, message2.Headers,
                 GetKeyId(iam), Keys.RSA, CompartmentId);
+        }
+
+        [TestMethod]
+        public async Task TestStaticDelegationTokenCacheAsync()
+        {
+            var provider =
+                IAMAuthorizationProvider.CreateWithInstancePrincipalForDelegation(
+                    DelegationToken);
+            provider.RefreshAhead = TimeSpan.Zero;
+
+            var client = new NoSQLClient(new NoSQLConfig
+            {
+                Region = TestRegion,
+                AuthorizationProvider = provider,
+                Compartment = CompartmentId
+            });
+            UseTestProfileProvider(provider);
+
+            var request = new GetTableRequest(client, "table", null);
+            var message1 = new HttpRequestMessage();
+            var message2 = new HttpRequestMessage();
+
+            try
+            {
+                await provider.ApplyAuthorizationAsync(request, message1,
+                    CancellationToken.None);
+                VerifyAuth(message1.Headers, CredentialsKeyId, Keys.RSA,
+                    CompartmentId, DelegationToken);
+
+                await provider.ApplyAuthorizationAsync(request, message2,
+                    CancellationToken.None);
+                VerifyAuthEqual(message2.Headers, message1.Headers,
+                    CredentialsKeyId, Keys.RSA, CompartmentId,
+                    DelegationToken);
+            }
+            finally
+            {
+                provider.Dispose();
+            }
+        }
+
+        [TestMethod]
+        public async Task TestDynamicDelegationTokenProviderCacheAsync()
+        {
+            var currentDelegationToken = DelegationToken;
+            var provider =
+                IAMAuthorizationProvider.CreateWithInstancePrincipalForDelegation(
+                    cancellationToken =>
+                        Task.FromResult(currentDelegationToken));
+            provider.RefreshAhead = TimeSpan.Zero;
+
+            var client = new NoSQLClient(new NoSQLConfig
+            {
+                Region = TestRegion,
+                AuthorizationProvider = provider,
+                Compartment = CompartmentId
+            });
+            UseTestProfileProvider(provider);
+
+            var request = new GetTableRequest(client, "table", null);
+            var message1 = new HttpRequestMessage();
+            var message2 = new HttpRequestMessage();
+            var message3 = new HttpRequestMessage();
+            var updatedDelegationToken = DelegationToken + "-updated";
+
+            try
+            {
+                await provider.ApplyAuthorizationAsync(request, message1,
+                    CancellationToken.None);
+                VerifyAuth(message1.Headers, CredentialsKeyId, Keys.RSA,
+                    CompartmentId, DelegationToken);
+
+                currentDelegationToken = updatedDelegationToken;
+                await provider.ApplyAuthorizationAsync(request, message2,
+                    CancellationToken.None);
+                VerifyAuth(message2.Headers, CredentialsKeyId, Keys.RSA,
+                    CompartmentId, updatedDelegationToken);
+                Assert.AreNotEqual(message1.Headers.Authorization?.ToString(),
+                    message2.Headers.Authorization?.ToString());
+
+                await provider.ApplyAuthorizationAsync(request, message3,
+                    CancellationToken.None);
+                VerifyAuthEqual(message3.Headers, message2.Headers,
+                    CredentialsKeyId, Keys.RSA, CompartmentId,
+                    updatedDelegationToken);
+            }
+            finally
+            {
+                provider.Dispose();
+            }
+        }
+
+        [TestMethod]
+        public async Task TestDynamicDelegationTokenFileCacheAsync()
+        {
+            var delegationTokenFile = Path.GetTempFileName();
+            IAMAuthorizationProvider provider = null;
+            try
+            {
+                File.WriteAllText(delegationTokenFile, DelegationToken);
+
+                provider = IAMAuthorizationProvider
+                    .CreateWithInstancePrincipalForDelegationFromFile(
+                        delegationTokenFile);
+                provider.RefreshAhead = TimeSpan.Zero;
+
+                var client = new NoSQLClient(new NoSQLConfig
+                {
+                    Region = TestRegion,
+                    AuthorizationProvider = provider,
+                    Compartment = CompartmentId
+                });
+                UseTestProfileProvider(provider);
+
+                var request = new GetTableRequest(client, "table", null);
+                var message1 = new HttpRequestMessage();
+                var message2 = new HttpRequestMessage();
+                var message3 = new HttpRequestMessage();
+                var updatedDelegationToken = DelegationToken + "-updated";
+
+                await provider.ApplyAuthorizationAsync(request, message1,
+                    CancellationToken.None);
+                VerifyAuth(message1.Headers, CredentialsKeyId, Keys.RSA,
+                    CompartmentId, DelegationToken);
+
+                File.WriteAllText(delegationTokenFile, updatedDelegationToken);
+                await provider.ApplyAuthorizationAsync(request, message2,
+                    CancellationToken.None);
+                VerifyAuth(message2.Headers, CredentialsKeyId, Keys.RSA,
+                    CompartmentId, updatedDelegationToken);
+                Assert.AreNotEqual(
+                    message1.Headers.Authorization?.ToString(),
+                    message2.Headers.Authorization?.ToString());
+
+                await provider.ApplyAuthorizationAsync(request, message3,
+                    CancellationToken.None);
+                VerifyAuthEqual(message3.Headers, message2.Headers,
+                    CredentialsKeyId, Keys.RSA, CompartmentId,
+                    updatedDelegationToken);
+            }
+            finally
+            {
+                provider?.Dispose();
+                File.Delete(delegationTokenFile);
+            }
         }
 
     }

--- a/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/Oracle.NoSQL.SDK.Tests.csproj
+++ b/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/Oracle.NoSQL.SDK.Tests.csproj
@@ -1,16 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
-	<RollForward>Major</RollForward>
-    <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="DeepCloner" Version="0.10.2" />
     <PackageReference Include="DeepEqual" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
   </ItemGroup>

--- a/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/RetrySafetyTests.cs
+++ b/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/RetrySafetyTests.cs
@@ -1,0 +1,237 @@
+/*-
+ * Copyright (c) 2020, 2025 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ *  https://oss.oracle.com/licenses/upl/
+ */
+
+namespace Oracle.NoSQL.SDK.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class RetrySafetyTests : TestBase
+    {
+        private const string TableName = "RetrySafetyTable";
+        private const string RegionId = "us-ashburn-1";
+
+        private static readonly Exception NetworkException =
+            new HttpRequestException("connection closed");
+
+        private static NoSQLClient MakeClient() =>
+            new NoSQLClient(new NoSQLConfig
+            {
+                ServiceType = ServiceType.CloudSim,
+                Endpoint = "localhost:8080"
+            });
+
+        private static MapValue MakeKey() => new MapValue
+        {
+            ["id"] = 1
+        };
+
+        private static MapValue MakeRow() => new MapValue
+        {
+            ["id"] = 1,
+            ["name"] = "retry"
+        };
+
+        private static bool ShouldRetry(Request request, Exception ex)
+        {
+            request.AddException(ex);
+            return new NoSQLRetryHandler().ShouldRetry(request);
+        }
+
+        private static PreparedStatement MakePreparedStatement(
+            sbyte operationCode) =>
+            new PreparedStatement
+            {
+                OperationCode = operationCode
+            };
+
+        public static IEnumerable<object[]> SafeNetworkRetryRequests
+        {
+            get
+            {
+                var client = MakeClient();
+
+                yield return new object[]
+                {
+                    "Get",
+                    new GetRequest<RecordValue>(client, TableName,
+                        MakeKey(), null)
+                };
+                yield return new object[]
+                {
+                    "GetTable",
+                    new GetTableRequest(client, TableName, null)
+                };
+                yield return new object[]
+                {
+                    "GetTableUsage",
+                    new GetTableUsageRequest(client, TableName, null)
+                };
+                yield return new object[]
+                {
+                    "GetIndexes",
+                    new GetIndexesRequest(client, TableName, null)
+                };
+                yield return new object[]
+                {
+                    "GetReplicaStats",
+                    new GetReplicaStatsRequest(client, TableName, RegionId,
+                        null)
+                };
+                yield return new object[]
+                {
+                    "ListTables",
+                    new ListTablesRequest(client, null)
+                };
+                yield return new object[]
+                {
+                    "Prepare",
+                    new PrepareRequest(client, $"SELECT * FROM {TableName}",
+                        null)
+                };
+                yield return new object[]
+                {
+                    "PreparedSelectQuery",
+                    new QueryRequest<RecordValue>(client,
+                        MakePreparedStatement(
+                            QueryRequest.OperationCodeSelect), null)
+                };
+                yield return new object[]
+                {
+                    "AdminStatus",
+                    new AdminStatusRequest(client, new AdminResult(client))
+                };
+            }
+        }
+
+        public static IEnumerable<object[]> UnsafeNetworkRetryRequests
+        {
+            get
+            {
+                var client = MakeClient();
+
+                yield return new object[]
+                {
+                    "Put",
+                    new PutRequest<RecordValue>(client, TableName,
+                        MakeRow(), null)
+                };
+                yield return new object[]
+                {
+                    "Delete",
+                    new DeleteRequest<RecordValue>(client, TableName,
+                        MakeKey(), null)
+                };
+                yield return new object[]
+                {
+                    "DeleteRange",
+                    new DeleteRangeRequest(client, TableName, MakeKey())
+                };
+                yield return new object[]
+                {
+                    "WriteMany",
+                    new WriteManyRequest<RecordValue>(client, TableName,
+                        new WriteOperationCollection().AddPut(MakeRow()),
+                        null)
+                };
+                yield return new object[]
+                {
+                    "TableDDL",
+                    new TableDDLRequest(client,
+                        $"CREATE TABLE {TableName}(id INTEGER, " +
+                        "PRIMARY KEY(id))", null)
+                };
+                yield return new object[]
+                {
+                    "TableLimits",
+                    new TableLimitsRequest(client, TableName,
+                        new TableLimits(1, 1, 1), null)
+                };
+                yield return new object[]
+                {
+                    "TableTags",
+                    new TableTagsRequest(client, TableName, null,
+                        new Dictionary<string, string>
+                        {
+                            ["owner"] = "retry-safety"
+                        }, null)
+                };
+                yield return new object[]
+                {
+                    "AddReplica",
+                    new AddReplicaRequest(client, TableName, RegionId)
+                };
+                yield return new object[]
+                {
+                    "DropReplica",
+                    new DropReplicaRequest(client, TableName, RegionId)
+                };
+                yield return new object[]
+                {
+                    "Admin",
+                    new AdminRequest(client, "CREATE USER test".ToCharArray(),
+                        null)
+                };
+                yield return new object[]
+                {
+                    "UnpreparedQuery",
+                    new QueryRequest<RecordValue>(client,
+                        $"SELECT * FROM {TableName}", null)
+                };
+                yield return new object[]
+                {
+                    "PreparedUpdateQuery",
+                    new QueryRequest<RecordValue>(client,
+                        MakePreparedStatement(
+                            (sbyte)(QueryRequest.OperationCodeSelect + 1)),
+                        null)
+                };
+            }
+        }
+
+        [TestMethod]
+        [DynamicData(nameof(SafeNetworkRetryRequests))]
+        public void ShouldRetrySafeRequestsOnNetworkException(string name,
+            Request request)
+        {
+            Assert.IsTrue(ShouldRetry(request, NetworkException), name);
+        }
+
+        [TestMethod]
+        [DynamicData(nameof(UnsafeNetworkRetryRequests))]
+        public void ShouldNotRetryUnsafeRequestsOnNetworkException(
+            string name, Request request)
+        {
+            Assert.IsFalse(ShouldRetry(request, NetworkException), name);
+        }
+
+        [TestMethod]
+        public void ShouldStillRetrySecurityInfoNotReadyForUnsafeRequests()
+        {
+            using var client = MakeClient();
+            var request = new PutRequest<RecordValue>(client, TableName,
+                MakeRow(), null);
+
+            Assert.IsTrue(ShouldRetry(request,
+                new SecurityInfoNotReadyException()));
+        }
+
+        [TestMethod]
+        public void ShouldStillRetryServerSideRetryableExceptionForWrites()
+        {
+            using var client = MakeClient();
+            var request = new PutRequest<RecordValue>(client, TableName,
+                MakeRow(), null);
+
+            Assert.IsTrue(ShouldRetry(request,
+                new WriteThrottlingException()));
+        }
+    }
+}

--- a/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/ServiceResponseExceptionTests.cs
+++ b/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/ServiceResponseExceptionTests.cs
@@ -1,0 +1,59 @@
+/*-
+ * Copyright (c) 2020, 2025 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ *  https://oss.oracle.com/licenses/upl/
+ */
+
+namespace Oracle.NoSQL.SDK.Tests
+{
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class ServiceResponseExceptionTests
+    {
+        [TestMethod]
+        public void TestMessageDoesNotIncludeResponseMessage()
+        {
+            const string responseMessage =
+                "Login failed for user admin with password secret-value";
+            var ex = new ServiceResponseException(
+                HttpStatusCode.InternalServerError,
+                "Internal Server Error",
+                responseMessage);
+
+            Assert.AreEqual(
+                "Unsuccessful HTTP response: 500 Internal Server Error",
+                ex.Message);
+            Assert.AreEqual(responseMessage, ex.ResponseMessage);
+            Assert.IsFalse(ex.Message.Contains(responseMessage));
+            Assert.IsFalse(ex.Message.Contains("secret-value"));
+        }
+
+        [TestMethod]
+        public async Task
+            TestHttpResponseExceptionDoesNotIncludeResponseBodyInMessage()
+        {
+            const string responseMessage =
+                "Unauthorized request with token secret-token";
+            using var response = new HttpResponseMessage(
+                HttpStatusCode.Unauthorized)
+            {
+                ReasonPhrase = "Unauthorized",
+                Content = new StringContent(responseMessage)
+            };
+
+            var ex = await HttpRequestUtils.CreateServiceResponseExceptionAsync(
+                response);
+
+            Assert.AreEqual("Unsuccessful HTTP response: 401 Unauthorized",
+                ex.Message);
+            Assert.AreEqual(responseMessage, ex.ResponseMessage);
+            Assert.IsFalse(ex.Message.Contains(responseMessage));
+            Assert.IsFalse(ex.Message.Contains("secret-token"));
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ and the [On-Premise Oracle NoSQL Database](https://docs.oracle.com/en/database/o
 
 ## Prerequisites
 
-* [.NET Core](https://dotnet.microsoft.com/download) 3.1 or later, including
-.NET 5.0, .NET 6.0 and later running on Windows, Linux, or Mac.
+* [.NET](https://dotnet.microsoft.com/download) 10.0 or later supported
+version running on Windows, Linux, or Mac.
 * Optionally,
 [Nuget Package Manager](https://docs.microsoft.com/en-us/nuget/consume-packages/install-use-packages-nuget-cli)
 if you wish to install the SDK independently of your project.
@@ -288,13 +288,10 @@ command, providing JSON config file as the command line argument:
 
 ```bash
 cd Oracle.NoSQL.SDK.Samples/<example>
-dotnet run -f <target-framework> [-- /path/to/config.json]
+dotnet run [-- /path/to/config.json]
 ```
 
-where *<example>* is the example directory and *<target-framework>* is the
-target framework moniker, supported values are *net5.0* and *netcoreapp3.1*,
-but both of these are forward-compatible and should run on any later .NET
-runtime as well.
+where *<example>* is the example directory.
 
 The command above will build and run the example.
 
@@ -302,7 +299,7 @@ For example:
 
 ```bash
 cd Oracle.NoSQL.SDK.Samples/BasicExample
-dotnet run -f net5.0 -- my_config.json
+dotnet run -- my_config.json
 ```
 
 ## Help

--- a/scripts/test-retry-hardening-cloud.sh
+++ b/scripts/test-retry-hardening-cloud.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TFM="${TFM:-net10.0}"
+CONFIG="${1:-${NOSQL_CONFIG_FILE:-}}"
+TEST_PROJECT="$ROOT/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/Oracle.NoSQL.SDK.Tests.csproj"
+SMOKE_PROJECT="$ROOT/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.SmokeTest/Oracle.NoSQL.SDK.SmokeTest.csproj"
+DOTNET="${DOTNET:-$(command -v dotnet || true)}"
+
+if [[ -z "$DOTNET" && -x /usr/local/share/dotnet/dotnet ]]; then
+    DOTNET=/usr/local/share/dotnet/dotnet
+fi
+
+if [[ -z "$DOTNET" ]]; then
+    echo "dotnet was not found. Set DOTNET=/path/to/dotnet."
+    exit 2
+fi
+
+if [[ -z "$CONFIG" ]]; then
+    echo "Usage: $0 /path/to/cloud-config.json"
+    echo "Or set NOSQL_CONFIG_FILE=/path/to/cloud-config.json"
+    exit 2
+fi
+
+echo "Building $TFM"
+"$DOTNET" build "$ROOT/Oracle.NoSQL.SDK.sln" -f "$TFM"
+
+echo "Running retry safety unit tests"
+"$DOTNET" test "$TEST_PROJECT" -f "$TFM" \
+    --filter "ClassName~RetrySafetyTests"
+
+echo "Running targeted cloud regression tests with $CONFIG"
+"$DOTNET" test "$TEST_PROJECT" -f "$TFM" \
+    --filter "ClassName~PutTests|ClassName~DeleteTests|ClassName~DeleteRangeTests|ClassName~WriteManyTests|ClassName~TableDDLTests" \
+    -- \
+    TestRunParameters.Parameter\(name=\"noSQLConfigFile\",value=\"$CONFIG\"\) \
+    TestRunParameters.Parameter\(name=\"skipRateLimiterTests\",value=\"true\"\)
+
+echo "Running cloud smoke test with $CONFIG"
+"$DOTNET" run -f "$TFM" --project "$SMOKE_PROJECT" -- "$CONFIG"

--- a/scripts/test-retry-hardening-local.sh
+++ b/scripts/test-retry-hardening-local.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TFM="${TFM:-net10.0}"
+CONFIG="${1:-${NOSQL_CONFIG_FILE:-$ROOT/Oracle.NoSQL.SDK.Samples/cloudsim.json}}"
+TEST_PROJECT="$ROOT/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/Oracle.NoSQL.SDK.Tests.csproj"
+SMOKE_PROJECT="$ROOT/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.SmokeTest/Oracle.NoSQL.SDK.SmokeTest.csproj"
+DOTNET="${DOTNET:-$(command -v dotnet || true)}"
+
+if [[ -z "$DOTNET" && -x /usr/local/share/dotnet/dotnet ]]; then
+    DOTNET=/usr/local/share/dotnet/dotnet
+fi
+
+if [[ -z "$DOTNET" ]]; then
+    echo "dotnet was not found. Set DOTNET=/path/to/dotnet."
+    exit 2
+fi
+
+echo "Building $TFM"
+"$DOTNET" build "$ROOT/Oracle.NoSQL.SDK.sln" -f "$TFM"
+
+echo "Running retry safety unit tests"
+"$DOTNET" test "$TEST_PROJECT" -f "$TFM" \
+    --filter "ClassName~RetrySafetyTests"
+
+echo "Running targeted local regression tests with $CONFIG"
+"$DOTNET" test "$TEST_PROJECT" -f "$TFM" \
+    --filter "ClassName~PutTests|ClassName~DeleteTests|ClassName~DeleteRangeTests|ClassName~WriteManyTests|ClassName~TableDDLTests" \
+    -- \
+    TestRunParameters.Parameter\(name=\"noSQLConfigFile\",value=\"$CONFIG\"\) \
+    TestRunParameters.Parameter\(name=\"skipRateLimiterTests\",value=\"true\"\)
+
+echo "Running local smoke test with $CONFIG"
+"$DOTNET" run -f "$TFM" --project "$SMOKE_PROJECT" -- "$CONFIG"


### PR DESCRIPTION
### Summary

Hardens instance principal metadata access by removing the automatic fallback from OCI IMDSv2 to IMDSv1.

The SDK now uses only the OCI IMDSv2 endpoint:

`http://169.254.169.254/opc/v2/`

with the required:

`Authorization: Bearer Oracle`

header.

### Motivation

The Jira finding flagged that `InstanceMetadataClient` retrieves instance principal identity material over OCI IMDS HTTP. OCI documents IMDS as a link-local HTTP endpoint, so the SDK cannot switch this path to HTTPS without platform support.

Previously, the SDK attempted IMDSv2 first, then silently fell back to IMDSv1 on 404. Since IMDSv2 is the recommended and stronger metadata protocol, this PR removes the IMDSv1 downgrade path.

### Changes

- Removed `http://169.254.169.254/opc/v1/` fallback from `InstanceMetadataClient`.
- Removed fallback handling for IMDSv1 `404`.
- Kept IMDSv2 metadata access with `Authorization: Bearer Oracle`.
- Added a short code comment explaining OCI IMDSv2 link-local HTTP behavior.

### Testing

- Built SDK successfully:

`/usr/local/share/dotnet/dotnet build Oracle.NoSQL.SDK/src/Oracle.NoSQL.SDK.csproj --no-restore`

- `dotnet test` compiled the projects but test execution aborted locally because the machine does not have the x64 dotnet host for the targeted test frameworks.

Note: This PR does not attempt to change OCI IMDS from HTTP to HTTPS because OCI documents IMDS as an HTTP link-local service. The SDK-side mitigation here is to remove the weaker IMDSv1 fallback and require IMDSv2.

Reference docs https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/gettingmetadata.htm
