### PR TITLE
KVSTORE-3327, Validate security token key binding

### DIFF
--- a/Oracle.NoSQL.SDK/src/Auth/IAM/AuthenticationProfileProvider.cs
+++ b/Oracle.NoSQL.SDK/src/Auth/IAM/AuthenticationProfileProvider.cs
@@ -264,6 +264,16 @@ namespace Oracle.NoSQL.SDK {
                     $"Security token from file {sessionTokenFile} is empty");
             }
 
+            var token = SecurityToken.Create(sessionToken);
+            if (!token.IsValid())
+            {
+                throw new ArgumentException(
+                    $"Security token from file {sessionTokenFile} " +
+                    "is expired");
+            }
+
+            token.ValidatePublicKey(privateKey);
+
             return new AuthenticationProfile("ST$" + sessionToken, privateKey,
                 tenantId);
         }

--- a/Oracle.NoSQL.SDK/src/Auth/IAM/SecurityToken.cs
+++ b/Oracle.NoSQL.SDK/src/Auth/IAM/SecurityToken.cs
@@ -8,6 +8,7 @@
 namespace Oracle.NoSQL.SDK {
 
     using System;
+    using System.Security.Cryptography;
     using System.Text.Json;
     using static Utils;
     using static DateTimeUtils;
@@ -45,6 +46,67 @@ namespace Oracle.NoSQL.SDK {
             }
 
             ExpirationTime = UnixMillisToDateTime(exp * 1000);
+
+            if (claims.TryGetProperty("jwk", out var jwkProp))
+            {
+                InitJWK(jwkProp);
+            }
+        }
+
+        private static byte[] Base64UrlDecodeBytes(string value)
+        {
+            var asBase64 = value.Replace('_', '/').Replace('-', '+');
+            if ((value.Length & 3) != 0)
+            {
+                asBase64 = asBase64.PadRight(
+                    ((asBase64.Length >> 2) + 1) << 2, '=');
+            }
+
+            return Convert.FromBase64String(asBase64);
+        }
+
+        private static RSAParameters GetJWKParameters(JsonElement jwk)
+        {
+            if (!jwk.TryGetProperty("n", out var modulusProp) ||
+                modulusProp.ValueKind != JsonValueKind.String)
+            {
+                throw new InvalidOperationException(
+                    "Invalid JWK in JWT, missing modulus");
+            }
+
+            if (!jwk.TryGetProperty("e", out var exponentProp) ||
+                exponentProp.ValueKind != JsonValueKind.String)
+            {
+                throw new InvalidOperationException(
+                    "Invalid JWK in JWT, missing exponent");
+            }
+
+            return new RSAParameters
+            {
+                Modulus = Base64UrlDecodeBytes(modulusProp.GetString()),
+                Exponent = Base64UrlDecodeBytes(exponentProp.GetString())
+            };
+        }
+
+        private void InitJWK(JsonElement jwkProp)
+        {
+            switch (jwkProp.ValueKind)
+            {
+                case JsonValueKind.String:
+                    using (var jwk = JsonDocument.Parse(
+                        jwkProp.GetString()))
+                    {
+                        PublicKey = GetJWKParameters(jwk.RootElement);
+                    }
+                    break;
+                case JsonValueKind.Object:
+                    PublicKey = GetJWKParameters(jwkProp);
+                    break;
+                default:
+                    throw new InvalidOperationException(
+                        "Invalid JWK claim value in JWT: " +
+                        jwkProp.GetRawText());
+            }
         }
 
         private protected void Init(string tokenName)
@@ -92,6 +154,34 @@ namespace Oracle.NoSQL.SDK {
 
         internal bool IsValid(TimeSpan expireBefore = default) =>
             ExpirationTime - expireBefore > DateTime.UtcNow;
+
+        private RSAParameters? PublicKey { get; set; }
+
+        internal void ValidatePublicKey(RSA expectedKey)
+        {
+            if (expectedKey == null)
+            {
+                throw new ArgumentNullException(nameof(expectedKey));
+            }
+
+            if (PublicKey == null)
+            {
+                throw new ArgumentException(
+                    "Security token is missing JWK public key");
+            }
+
+            var expected = expectedKey.ExportParameters(false);
+            var actual = PublicKey.Value;
+            if (!CryptographicOperations.FixedTimeEquals(
+                    actual.Modulus, expected.Modulus) ||
+                !CryptographicOperations.FixedTimeEquals(
+                    actual.Exponent, expected.Exponent))
+            {
+                throw new ArgumentException(
+                    "Security token JWK public key does not match " +
+                    "the configured private key");
+            }
+        }
     }
 
     internal class ResourcePrincipalSecurityToken : SecurityToken

--- a/Oracle.NoSQL.SDK/src/Auth/IAM/SecurityTokenBasedProvider.cs
+++ b/Oracle.NoSQL.SDK/src/Auth/IAM/SecurityTokenBasedProvider.cs
@@ -47,6 +47,7 @@ namespace Oracle.NoSQL.SDK
             {
                 securityToken = CreateSecurityToken(
                     await RefreshSecurityTokenAsync(cancellationToken));
+                securityToken.ValidatePublicKey(PrivateKey);
             }
 
             return new AuthenticationProfile("ST$" + securityToken.Value,

--- a/Oracle.NoSQL.SDK/src/Auth/IAM/SecurityTokenBasedProvider.cs
+++ b/Oracle.NoSQL.SDK/src/Auth/IAM/SecurityTokenBasedProvider.cs
@@ -45,9 +45,10 @@ namespace Oracle.NoSQL.SDK
         {
             if (forceRefresh || !IsProfileValid)
             {
-                securityToken = CreateSecurityToken(
+                var refreshedToken = CreateSecurityToken(
                     await RefreshSecurityTokenAsync(cancellationToken));
-                securityToken.ValidatePublicKey(PrivateKey);
+                refreshedToken.ValidatePublicKey(PrivateKey);
+                securityToken = refreshedToken;
             }
 
             return new AuthenticationProfile("ST$" + securityToken.Value,

--- a/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/IAM/AuthProviderTests.Negative.cs
+++ b/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/IAM/AuthProviderTests.Negative.cs
@@ -171,7 +171,18 @@ namespace Oracle.NoSQL.SDK.Tests.IAM
                 // Empty session token
                 .Append(new OCIConfigInfo(
                     DefaultProfileStart.Concat(OCIConfigLinesSessToken),
-                    Keys.PrivatePKCS8PEM, null, string.Empty));
+                    Keys.PrivatePKCS8PEM, null, string.Empty))
+                // Session token JWK does not match configured private key
+                .Append(new OCIConfigInfo(
+                    DefaultProfileStart.Concat(OCIConfigLinesSessToken),
+                    Keys.PrivatePKCS8PEM, null,
+                    Utils.CreateSecurityTokenWithNewKey()))
+                // Expired session token
+                .Append(new OCIConfigInfo(
+                    DefaultProfileStart.Concat(OCIConfigLinesSessToken),
+                    Keys.PrivatePKCS8PEM, null,
+                    Utils.CreateSecurityToken(Keys.RSA,
+                        TimeSpan.FromMinutes(-1))));
 
         private static readonly
             IEnumerable<Func<CancellationToken, Task<IAMCredentials>>>

--- a/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/IAM/SecurityTokenTests.cs
+++ b/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/IAM/SecurityTokenTests.cs
@@ -70,15 +70,36 @@ namespace Oracle.NoSQL.SDK.Tests.IAM
             Assert.AreEqual(2, provider.RefreshCount);
         }
 
+        [TestMethod]
+        public async Task TestInvalidForcedRefreshDoesNotReplaceCachedToken()
+        {
+            var validToken = CreateSecurityToken(Keys.RSA);
+            var invalidToken = CreateSecurityTokenWithNewKey();
+            var provider = new TestSecurityTokenBasedProvider(
+                validToken, invalidToken);
+
+            var profile = await provider.GetProfileAsync(true,
+                CancellationToken.None);
+            Assert.AreEqual(GetKeyIdFromToken(validToken), profile.KeyId);
+
+            await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+                provider.GetProfileAsync(true, CancellationToken.None));
+
+            profile = await provider.GetProfileAsync(false,
+                CancellationToken.None);
+            Assert.AreEqual(GetKeyIdFromToken(validToken), profile.KeyId);
+            Assert.AreEqual(2, provider.RefreshCount);
+        }
+
         private class TestSecurityTokenBasedProvider :
             SecurityTokenBasedProvider
         {
-            private readonly string token;
+            private readonly string[] tokens;
 
-            internal TestSecurityTokenBasedProvider(string token) :
+            internal TestSecurityTokenBasedProvider(params string[] tokens) :
                 base(TimeSpan.Zero)
             {
-                this.token = token;
+                this.tokens = tokens;
             }
 
             internal int RefreshCount { get; private set; }
@@ -88,6 +109,8 @@ namespace Oracle.NoSQL.SDK.Tests.IAM
             private protected override Task<string> RefreshSecurityTokenAsync(
                 CancellationToken cancellationToken)
             {
+                var token = tokens[Math.Min(RefreshCount,
+                    tokens.Length - 1)];
                 RefreshCount++;
                 return Task.FromResult(token);
             }

--- a/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/IAM/SecurityTokenTests.cs
+++ b/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/IAM/SecurityTokenTests.cs
@@ -1,0 +1,56 @@
+/*-
+ * Copyright (c) 2020, 2025 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ *  https://oss.oracle.com/licenses/upl/
+ */
+
+namespace Oracle.NoSQL.SDK.Tests.IAM
+{
+    using System;
+    using System.Security.Cryptography;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using static TestData;
+    using static Utils;
+
+    [TestClass]
+    public class SecurityTokenTests
+    {
+        [TestMethod]
+        public void TestSecurityTokenValidatesMatchingPublicKey()
+        {
+            var token = SecurityToken.Create(CreateSecurityToken(Keys.RSA));
+
+            token.ValidatePublicKey(Keys.RSA);
+        }
+
+        [TestMethod]
+        public void TestSecurityTokenRejectsMismatchedPublicKey()
+        {
+            using var otherKey = RSA.Create(2048);
+            var token = SecurityToken.Create(CreateSecurityToken(Keys.RSA));
+
+            Assert.ThrowsException<ArgumentException>(() =>
+                token.ValidatePublicKey(otherKey));
+        }
+
+        [TestMethod]
+        public void TestSecurityTokenRejectsMissingJWK()
+        {
+            var token = SecurityToken.Create(CreateSecurityToken(Keys.RSA,
+                includeJWK: false));
+
+            Assert.ThrowsException<ArgumentException>(() =>
+                token.ValidatePublicKey(Keys.RSA));
+        }
+
+        [TestMethod]
+        public void TestSecurityTokenDetectsExpiredToken()
+        {
+            var token = SecurityToken.Create(CreateSecurityToken(Keys.RSA,
+                TimeSpan.FromMinutes(-1)));
+
+            Assert.IsFalse(token.IsValid());
+        }
+    }
+}

--- a/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/IAM/SecurityTokenTests.cs
+++ b/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/IAM/SecurityTokenTests.cs
@@ -9,6 +9,8 @@ namespace Oracle.NoSQL.SDK.Tests.IAM
 {
     using System;
     using System.Security.Cryptography;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using static TestData;
     using static Utils;
@@ -51,6 +53,48 @@ namespace Oracle.NoSQL.SDK.Tests.IAM
                 TimeSpan.FromMinutes(-1)));
 
             Assert.IsFalse(token.IsValid());
+        }
+
+        [TestMethod]
+        public async Task TestInvalidRefreshedTokenIsNotCached()
+        {
+            var provider = new TestSecurityTokenBasedProvider(
+                CreateSecurityTokenWithNewKey());
+
+            await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+                provider.GetProfileAsync(true, CancellationToken.None));
+
+            await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+                provider.GetProfileAsync(false, CancellationToken.None));
+
+            Assert.AreEqual(2, provider.RefreshCount);
+        }
+
+        private class TestSecurityTokenBasedProvider :
+            SecurityTokenBasedProvider
+        {
+            private readonly string token;
+
+            internal TestSecurityTokenBasedProvider(string token) :
+                base(TimeSpan.Zero)
+            {
+                this.token = token;
+            }
+
+            internal int RefreshCount { get; private set; }
+
+            private protected override RSA PrivateKey => Keys.RSA;
+
+            private protected override Task<string> RefreshSecurityTokenAsync(
+                CancellationToken cancellationToken)
+            {
+                RefreshCount++;
+                return Task.FromResult(token);
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+            }
         }
     }
 }

--- a/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/IAM/TestData.cs
+++ b/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/IAM/TestData.cs
@@ -27,9 +27,11 @@ namespace Oracle.NoSQL.SDK.Tests.IAM
         internal const string TenantId = "ocid1.tenancy.oc1..tenancy";
         internal const string UserId = "ocid1.user.oc1..user";
         internal const string Fingerprint = "fingerprint";
-        
-        internal const string SessionToken =
-            "token-header.token-payload.token-sig";
+
+        internal static readonly RSAKeys Keys = new RSAKeys();
+
+        internal static readonly string SessionToken =
+            Utils.CreateSecurityToken(Keys.RSA);
 
         internal const string DelegationToken =
             "token-header.token-payload.token-sig";
@@ -60,8 +62,6 @@ namespace Oracle.NoSQL.SDK.Tests.IAM
 
         internal static readonly string DelegationTokenFile =
             TempFileCache.GetTempFile();
-
-        internal static readonly RSAKeys Keys = new RSAKeys();
 
         internal static readonly IAMCredentials CredentialsBase =
             new IAMCredentials

--- a/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/IAM/Utils.cs
+++ b/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/IAM/Utils.cs
@@ -17,6 +17,7 @@ namespace Oracle.NoSQL.SDK.Tests.IAM
     using System.Reflection;
     using System.Security.Cryptography;
     using System.Text;
+    using System.Text.Json;
     using System.Text.RegularExpressions;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using static TestData;
@@ -120,6 +121,54 @@ namespace Oracle.NoSQL.SDK.Tests.IAM
 
         internal static string GetKeyIdFromToken(string token) =>
             "ST$" + token;
+
+        private static string Base64UrlEncode(byte[] data) =>
+            Convert.ToBase64String(data)
+                .TrimEnd('=')
+                .Replace('+', '-')
+                .Replace('/', '_');
+
+        internal static string CreateSecurityToken(RSA publicKey,
+            TimeSpan? lifetime = null, bool includeJWK = true)
+        {
+            var header = JsonSerializer.Serialize(new
+            {
+                kid = "test-key-id",
+                alg = "RS256"
+            });
+
+            var exp = DateTimeOffset.UtcNow.Add(
+                lifetime ?? TimeSpan.FromHours(1)).ToUnixTimeSeconds();
+            var publicParams = publicKey.ExportParameters(false);
+            var payload = new Dictionary<string, object>
+            {
+                ["exp"] = exp,
+                ["iss"] = "authService.oracle.com",
+                ["aud"] = "oci"
+            };
+
+            if (includeJWK)
+            {
+                payload["jwk"] = JsonSerializer.Serialize(new
+                {
+                    kty = "RSA",
+                    n = Base64UrlEncode(publicParams.Modulus),
+                    e = Base64UrlEncode(publicParams.Exponent),
+                    kid = "Ignored"
+                });
+            }
+
+            return Base64UrlEncode(Encoding.UTF8.GetBytes(header)) + "." +
+                Base64UrlEncode(Encoding.UTF8.GetBytes(
+                    JsonSerializer.Serialize(payload))) + ".signature";
+        }
+
+        internal static string CreateSecurityTokenWithNewKey(
+            TimeSpan? lifetime = null)
+        {
+            using var rsa = RSA.Create(2048);
+            return CreateSecurityToken(rsa, lifetime);
+        }
 
         internal static string[] GetOCIConfigLines(string profileName,
             IAMCredentials credentials, string region = null) => new string[]


### PR DESCRIPTION
Parse embedded token JWK values and verify they match the RSA public key derived from the configured signing private key before trusting security tokens. Apply the same validation to token-based providers and session tokens loaded from disk.