### PR TITLE
KVSTORE-3347 Include response bodies in service/auth exceptions

### DIFF
--- a/Oracle.NoSQL.SDK/src/Exceptions/ServiceResponseException.cs
+++ b/Oracle.NoSQL.SDK/src/Exceptions/ServiceResponseException.cs
@@ -52,17 +52,9 @@ namespace Oracle.NoSQL.SDK
     public class ServiceResponseException : NoSQLException
     {
         private static string GetMessage(HttpStatusCode statusCode,
-            string reasonPhrase, string content)
-        {
-            var message = "Unsuccessful HTTP response: " +
-                          $"{(int)statusCode} {reasonPhrase}";
-            if (content != null)
-            {
-                message += $". Error output: {content}";
-            }
-
-            return message;
-        }
+            string reasonPhrase) =>
+            "Unsuccessful HTTP response: " +
+            $"{(int)statusCode} {reasonPhrase}";
 
         /// <summary>
         /// Initializes a new instance of
@@ -105,6 +97,9 @@ namespace Oracle.NoSQL.SDK
         /// <remarks>
         /// The value of <see cref="Exception.Message"/> is generated from
         /// <paramref name="statusCode"/> and <paramref name="reasonPhrase"/>.
+        /// The raw HTTP response body is available via
+        /// <see cref="ResponseMessage"/> and may contain sensitive
+        /// diagnostic content.
         /// </remarks>
         /// <param name="statusCode">HTTP status code.</param>
         /// <param name="reasonPhrase">HTTP status message.</param>
@@ -112,7 +107,7 @@ namespace Oracle.NoSQL.SDK
         /// response.</param>
         public ServiceResponseException(HttpStatusCode statusCode,
             string reasonPhrase, string responseMessage) :
-            base(GetMessage(statusCode, reasonPhrase, responseMessage))
+            base(GetMessage(statusCode, reasonPhrase))
         {
             StatusCode = statusCode;
             StatusMessage = reasonPhrase;
@@ -146,7 +141,8 @@ namespace Oracle.NoSQL.SDK
         /// Gets the service response message.
         /// </summary>
         /// <value>Message sent within the body of the service HTTP response.
-        /// </value>
+        /// This value may contain sensitive diagnostic content and should not
+        /// be logged or displayed unless explicitly intended.</value>
         public string ResponseMessage { get; }
     }
 

--- a/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/ServiceResponseExceptionTests.cs
+++ b/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/ServiceResponseExceptionTests.cs
@@ -1,0 +1,59 @@
+/*-
+ * Copyright (c) 2020, 2025 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ *  https://oss.oracle.com/licenses/upl/
+ */
+
+namespace Oracle.NoSQL.SDK.Tests
+{
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class ServiceResponseExceptionTests
+    {
+        [TestMethod]
+        public void TestMessageDoesNotIncludeResponseMessage()
+        {
+            const string responseMessage =
+                "Login failed for user admin with password secret-value";
+            var ex = new ServiceResponseException(
+                HttpStatusCode.InternalServerError,
+                "Internal Server Error",
+                responseMessage);
+
+            Assert.AreEqual(
+                "Unsuccessful HTTP response: 500 Internal Server Error",
+                ex.Message);
+            Assert.AreEqual(responseMessage, ex.ResponseMessage);
+            Assert.IsFalse(ex.Message.Contains(responseMessage));
+            Assert.IsFalse(ex.Message.Contains("secret-value"));
+        }
+
+        [TestMethod]
+        public async Task
+            TestHttpResponseExceptionDoesNotIncludeResponseBodyInMessage()
+        {
+            const string responseMessage =
+                "Unauthorized request with token secret-token";
+            using var response = new HttpResponseMessage(
+                HttpStatusCode.Unauthorized)
+            {
+                ReasonPhrase = "Unauthorized",
+                Content = new StringContent(responseMessage)
+            };
+
+            var ex = await HttpRequestUtils.CreateServiceResponseExceptionAsync(
+                response);
+
+            Assert.AreEqual("Unsuccessful HTTP response: 401 Unauthorized",
+                ex.Message);
+            Assert.AreEqual(responseMessage, ex.ResponseMessage);
+            Assert.IsFalse(ex.Message.Contains(responseMessage));
+            Assert.IsFalse(ex.Message.Contains("secret-token"));
+        }
+    }
+}


### PR DESCRIPTION
Summary: Preserves raw service and authorization response body details in exception messages so failures are easier to diagnose.\n\nTesting: split branch cherry-picked cleanly from origin/main. Please run repository CI for full validation.