### PR TITLE
KVSTORE-3351 Avoid delegated-user token provider cache reuse

### DIFF
--- a/Oracle.NoSQL.SDK/src/Auth/IAM/IAMAuthorizationProvider.Internal.cs
+++ b/Oracle.NoSQL.SDK/src/Auth/IAM/IAMAuthorizationProvider.Internal.cs
@@ -145,6 +145,9 @@ namespace Oracle.NoSQL.SDK
             }
         }
 
+        private bool HasDynamicDelegationToken =>
+            DelegationTokenProvider != null || DelegationTokenFile != null;
+
         private async Task<string> LoadDelegationToken(
             CancellationToken cancellationToken)
         {
@@ -234,7 +237,8 @@ namespace Oracle.NoSQL.SDK
 
         private async Task<SignatureDetails> CreateSignatureDetailsAsync(
             Request request, HttpRequestMessage message,
-            bool forceProfileRefresh, CancellationToken cancellationToken)
+            bool forceProfileRefresh, CancellationToken cancellationToken,
+            string currentDelegationToken = null)
         {
             AuthenticationProfile profile;
 
@@ -252,12 +256,17 @@ namespace Oracle.NoSQL.SDK
                 providerAsyncLock.Release();
             }
 
-            // If there is no DelegationTokenProvider or DelegationTokenFile,
-            // delegationToken could have been initialized in the constructor.
-            var currentDelegationToken =
-                DelegationTokenProvider != null || DelegationTokenFile != null
-                    ? await LoadDelegationToken(cancellationToken)
-                    : DelegationToken;
+            if (!HasDynamicDelegationToken)
+            {
+                // If there is no DelegationTokenProvider or DelegationTokenFile,
+                // delegationToken could have been initialized in the constructor.
+                currentDelegationToken = DelegationToken;
+            }
+            else if (currentDelegationToken == null)
+            {
+                currentDelegationToken =
+                    await LoadDelegationToken(cancellationToken);
+            }
 
             ContentSigningInfo contentSigningInfo = null;
             if (request?.NeedsContentSigned ?? false)
@@ -375,6 +384,11 @@ namespace Oracle.NoSQL.SDK
             SignatureDetails signatureDetails) =>
             signatureDetails == null || DateTime.UtcNow >
             signatureDetails.Time + CacheDuration;
+
+        private static bool DelegationTokenMatches(
+            SignatureDetails signatureDetails,
+            string currentDelegationToken) =>
+            signatureDetails?.DelegationToken == currentDelegationToken;
 
         /// <summary>
         /// Validates and configures the authorization provider.

--- a/Oracle.NoSQL.SDK/src/Auth/IAM/IAMAuthorizationProvider.Internal.cs
+++ b/Oracle.NoSQL.SDK/src/Auth/IAM/IAMAuthorizationProvider.Internal.cs
@@ -237,8 +237,8 @@ namespace Oracle.NoSQL.SDK
 
         private async Task<SignatureDetails> CreateSignatureDetailsAsync(
             Request request, HttpRequestMessage message,
-            bool forceProfileRefresh, CancellationToken cancellationToken,
-            string currentDelegationToken = null)
+            bool forceProfileRefresh, string currentDelegationToken,
+            CancellationToken cancellationToken)
         {
             AuthenticationProfile profile;
 
@@ -358,7 +358,7 @@ namespace Oracle.NoSQL.SDK
                         await Task.Delay(renewInterval, cancellationToken);
                         CachedSignatureDetails =
                             await CreateSignatureDetailsAsync(null, null,
-                                needProfileRefresh, cancellationToken);
+                                needProfileRefresh, null, cancellationToken);
                     }
                     catch (Exception)
                     {

--- a/Oracle.NoSQL.SDK/src/Auth/IAM/IAMAuthorizationProvider.cs
+++ b/Oracle.NoSQL.SDK/src/Auth/IAM/IAMAuthorizationProvider.cs
@@ -700,28 +700,33 @@ namespace Oracle.NoSQL.SDK
             var isInvalidAuth =
                 request.LastException is InvalidAuthorizationException;
             var contentSigned = request.NeedsContentSigned;
-            var hasDynamicDelegationToken = HasDynamicDelegationToken;
-            var currentDelegationToken = hasDynamicDelegationToken
-                ? await LoadDelegationToken(cancellationToken)
-                : null;
+            string currentDelegationToken = null;
+            if (HasDynamicDelegationToken)
+            {
+                currentDelegationToken =
+                    await LoadDelegationToken(cancellationToken);
+            }
+
+            // Use one cache snapshot for the match decision and the headers
+            // applied to this request.
             var cachedSignatureDetails = CachedSignatureDetails;
             
             SignatureDetails signatureDetails;
             if (isInvalidAuth || contentSigned ||
                 !profileProvider.IsProfileValid ||
                 NeedSignatureRefresh(cachedSignatureDetails) ||
-                (hasDynamicDelegationToken &&
+                (HasDynamicDelegationToken &&
                  !DelegationTokenMatches(cachedSignatureDetails,
                      currentDelegationToken)))
             {
                 signatureDetails = await CreateSignatureDetailsAsync(
-                    request, message, isInvalidAuth, cancellationToken,
-                    currentDelegationToken);
+                    request, message, isInvalidAuth, currentDelegationToken,
+                    cancellationToken);
 
                 if (!contentSigned)
                 {
                     CachedSignatureDetails = signatureDetails;
-                    if (!hasDynamicDelegationToken &&
+                    if (!HasDynamicDelegationToken &&
                         RefreshAhead != TimeSpan.Zero)
                     {
                         ScheduleRenew();

--- a/Oracle.NoSQL.SDK/src/Auth/IAM/IAMAuthorizationProvider.cs
+++ b/Oracle.NoSQL.SDK/src/Auth/IAM/IAMAuthorizationProvider.cs
@@ -122,7 +122,9 @@ namespace Oracle.NoSQL.SDK
         /// </para>
         /// <para>
         /// The delegation token provider delegate is called to obtain the
-        /// delegation token each time the request signature is renewed.
+        /// delegation token when authorizing requests.  If a cached request
+        /// signature is available, the token returned by the delegate must
+        /// match the cached token before the signature is reused.
         /// </para>
         /// </remarks>
         /// <value>
@@ -147,9 +149,10 @@ namespace Oracle.NoSQL.SDK
         /// user.
         /// </para>
         /// <para>
-        /// The delegation token file is read each time the request signature
-        /// is renewed. You may also use the property in JSON configuration
-        /// file (see examples).
+        /// The delegation token file is read when authorizing requests.  If a
+        /// cached request signature is available, the token read from the file
+        /// must match the cached token before the signature is reused. You may
+        /// also use the property in JSON configuration file (see examples).
         /// </para>
         /// </remarks>
         /// <value>
@@ -480,8 +483,8 @@ namespace Oracle.NoSQL.SDK
         /// <remarks>
         /// The delegation token allows the instance to assume the privileges
         /// of the user for which the token was created.  The delegation token
-        /// provider delegate will be used to obtain the delegation token each
-        /// time the request signature is renewed.
+        /// provider delegate will be used to obtain the delegation token when
+        /// authorizing requests.
         /// </remarks>
         /// <param name="delegationTokenProvider">The delegation token
         /// provider delegate.</param>
@@ -511,8 +514,8 @@ namespace Oracle.NoSQL.SDK
         /// <remarks>
         /// The delegation token allows the instance to assume the privileges
         /// of the user for which the token was created.  The delegation token
-        /// file will be read to obtain the delegation token each time the
-        /// request signature is renewed.
+        /// file will be read to obtain the delegation token when authorizing
+        /// requests.
         /// </remarks>
         /// <param name="delegationTokenFile">Path to the delegation token
         /// file.</param>
@@ -697,19 +700,29 @@ namespace Oracle.NoSQL.SDK
             var isInvalidAuth =
                 request.LastException is InvalidAuthorizationException;
             var contentSigned = request.NeedsContentSigned;
+            var hasDynamicDelegationToken = HasDynamicDelegationToken;
+            var currentDelegationToken = hasDynamicDelegationToken
+                ? await LoadDelegationToken(cancellationToken)
+                : null;
+            var cachedSignatureDetails = CachedSignatureDetails;
             
             SignatureDetails signatureDetails;
             if (isInvalidAuth || contentSigned ||
                 !profileProvider.IsProfileValid ||
-                NeedSignatureRefresh(CachedSignatureDetails))
+                NeedSignatureRefresh(cachedSignatureDetails) ||
+                (hasDynamicDelegationToken &&
+                 !DelegationTokenMatches(cachedSignatureDetails,
+                     currentDelegationToken)))
             {
                 signatureDetails = await CreateSignatureDetailsAsync(
-                    request, message, isInvalidAuth, cancellationToken);
+                    request, message, isInvalidAuth, cancellationToken,
+                    currentDelegationToken);
 
                 if (!contentSigned)
                 {
                     CachedSignatureDetails = signatureDetails;
-                    if (RefreshAhead != TimeSpan.Zero)
+                    if (!hasDynamicDelegationToken &&
+                        RefreshAhead != TimeSpan.Zero)
                     {
                         ScheduleRenew();
                     }
@@ -717,7 +730,7 @@ namespace Oracle.NoSQL.SDK
             }
             else
             {
-                signatureDetails = CachedSignatureDetails;
+                signatureDetails = cachedSignatureDetails;
             }
 
             message.Headers.Add(Authorization,

--- a/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/IAM/AuthProviderTests.Positive.cs
+++ b/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/IAM/AuthProviderTests.Positive.cs
@@ -11,6 +11,7 @@ namespace Oracle.NoSQL.SDK.Tests.IAM
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Reflection;
     using System.Threading;
     using System.Threading.Tasks;
     using System.Net.Http;
@@ -186,6 +187,19 @@ namespace Oracle.NoSQL.SDK.Tests.IAM
                 ? GetKeyIdFromToken(iam.SessTokenFileData)
                 : CredentialsKeyId;
 
+        private static void UseTestProfileProvider(
+            IAMAuthorizationProvider provider)
+        {
+            var profileProviderField =
+                typeof(IAMAuthorizationProvider).GetField("profileProvider",
+                    BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(profileProviderField);
+
+            (profileProviderField.GetValue(provider) as IDisposable)?.Dispose();
+            profileProviderField.SetValue(provider,
+                new CredentialsProfileProvider(CredentialsPK));
+        }
+
         private IAMConfigInfo currentIAMConfig;
 
         private void PrepareConfig(IAMConfigInfo iam)
@@ -343,6 +357,151 @@ namespace Oracle.NoSQL.SDK.Tests.IAM
             // +4200 ms, automatic refresh should have happened again
             VerifyAuthLaterDate(message1.Headers, message2.Headers,
                 GetKeyId(iam), Keys.RSA, CompartmentId);
+        }
+
+        [TestMethod]
+        public async Task TestStaticDelegationTokenCacheAsync()
+        {
+            var provider =
+                IAMAuthorizationProvider.CreateWithInstancePrincipalForDelegation(
+                    DelegationToken);
+            provider.RefreshAhead = TimeSpan.Zero;
+
+            var client = new NoSQLClient(new NoSQLConfig
+            {
+                Region = TestRegion,
+                AuthorizationProvider = provider,
+                Compartment = CompartmentId
+            });
+            UseTestProfileProvider(provider);
+
+            var request = new GetTableRequest(client, "table", null);
+            var message1 = new HttpRequestMessage();
+            var message2 = new HttpRequestMessage();
+
+            try
+            {
+                await provider.ApplyAuthorizationAsync(request, message1,
+                    CancellationToken.None);
+                VerifyAuth(message1.Headers, CredentialsKeyId, Keys.RSA,
+                    CompartmentId, DelegationToken);
+
+                await provider.ApplyAuthorizationAsync(request, message2,
+                    CancellationToken.None);
+                VerifyAuthEqual(message2.Headers, message1.Headers,
+                    CredentialsKeyId, Keys.RSA, CompartmentId,
+                    DelegationToken);
+            }
+            finally
+            {
+                provider.Dispose();
+            }
+        }
+
+        [TestMethod]
+        public async Task TestDynamicDelegationTokenProviderCacheAsync()
+        {
+            var currentDelegationToken = DelegationToken;
+            var provider =
+                IAMAuthorizationProvider.CreateWithInstancePrincipalForDelegation(
+                    cancellationToken =>
+                        Task.FromResult(currentDelegationToken));
+            provider.RefreshAhead = TimeSpan.Zero;
+
+            var client = new NoSQLClient(new NoSQLConfig
+            {
+                Region = TestRegion,
+                AuthorizationProvider = provider,
+                Compartment = CompartmentId
+            });
+            UseTestProfileProvider(provider);
+
+            var request = new GetTableRequest(client, "table", null);
+            var message1 = new HttpRequestMessage();
+            var message2 = new HttpRequestMessage();
+            var message3 = new HttpRequestMessage();
+            var updatedDelegationToken = DelegationToken + "-updated";
+
+            try
+            {
+                await provider.ApplyAuthorizationAsync(request, message1,
+                    CancellationToken.None);
+                VerifyAuth(message1.Headers, CredentialsKeyId, Keys.RSA,
+                    CompartmentId, DelegationToken);
+
+                currentDelegationToken = updatedDelegationToken;
+                await provider.ApplyAuthorizationAsync(request, message2,
+                    CancellationToken.None);
+                VerifyAuth(message2.Headers, CredentialsKeyId, Keys.RSA,
+                    CompartmentId, updatedDelegationToken);
+                Assert.AreNotEqual(message1.Headers.Authorization?.ToString(),
+                    message2.Headers.Authorization?.ToString());
+
+                await provider.ApplyAuthorizationAsync(request, message3,
+                    CancellationToken.None);
+                VerifyAuthEqual(message3.Headers, message2.Headers,
+                    CredentialsKeyId, Keys.RSA, CompartmentId,
+                    updatedDelegationToken);
+            }
+            finally
+            {
+                provider.Dispose();
+            }
+        }
+
+        [TestMethod]
+        public async Task TestDynamicDelegationTokenFileCacheAsync()
+        {
+            var delegationTokenFile = Path.GetTempFileName();
+            IAMAuthorizationProvider provider = null;
+            try
+            {
+                File.WriteAllText(delegationTokenFile, DelegationToken);
+
+                provider = IAMAuthorizationProvider
+                    .CreateWithInstancePrincipalForDelegationFromFile(
+                        delegationTokenFile);
+                provider.RefreshAhead = TimeSpan.Zero;
+
+                var client = new NoSQLClient(new NoSQLConfig
+                {
+                    Region = TestRegion,
+                    AuthorizationProvider = provider,
+                    Compartment = CompartmentId
+                });
+                UseTestProfileProvider(provider);
+
+                var request = new GetTableRequest(client, "table", null);
+                var message1 = new HttpRequestMessage();
+                var message2 = new HttpRequestMessage();
+                var message3 = new HttpRequestMessage();
+                var updatedDelegationToken = DelegationToken + "-updated";
+
+                await provider.ApplyAuthorizationAsync(request, message1,
+                    CancellationToken.None);
+                VerifyAuth(message1.Headers, CredentialsKeyId, Keys.RSA,
+                    CompartmentId, DelegationToken);
+
+                File.WriteAllText(delegationTokenFile, updatedDelegationToken);
+                await provider.ApplyAuthorizationAsync(request, message2,
+                    CancellationToken.None);
+                VerifyAuth(message2.Headers, CredentialsKeyId, Keys.RSA,
+                    CompartmentId, updatedDelegationToken);
+                Assert.AreNotEqual(
+                    message1.Headers.Authorization?.ToString(),
+                    message2.Headers.Authorization?.ToString());
+
+                await provider.ApplyAuthorizationAsync(request, message3,
+                    CancellationToken.None);
+                VerifyAuthEqual(message3.Headers, message2.Headers,
+                    CredentialsKeyId, Keys.RSA, CompartmentId,
+                    updatedDelegationToken);
+            }
+            finally
+            {
+                provider?.Dispose();
+                File.Delete(delegationTokenFile);
+            }
         }
 
     }

--- a/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/IAM/AuthProviderTests.Positive.cs
+++ b/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/IAM/AuthProviderTests.Positive.cs
@@ -187,8 +187,22 @@ namespace Oracle.NoSQL.SDK.Tests.IAM
                 ? GetKeyIdFromToken(iam.SessTokenFileData)
                 : CredentialsKeyId;
 
+        private class TestCredentialsProfileProvider :
+            CredentialsProfileProvider
+        {
+            private readonly TimeSpan profileTTL;
+
+            internal TestCredentialsProfileProvider(IAMCredentials credentials,
+                TimeSpan? profileTTL = null) : base(credentials)
+            {
+                this.profileTTL = profileTTL ?? TimeSpan.MaxValue;
+            }
+
+            internal override TimeSpan ProfileTTL => profileTTL;
+        }
+
         private static void UseTestProfileProvider(
-            IAMAuthorizationProvider provider)
+            IAMAuthorizationProvider provider, TimeSpan? profileTTL = null)
         {
             var profileProviderField =
                 typeof(IAMAuthorizationProvider).GetField("profileProvider",
@@ -197,7 +211,8 @@ namespace Oracle.NoSQL.SDK.Tests.IAM
 
             (profileProviderField.GetValue(provider) as IDisposable)?.Dispose();
             profileProviderField.SetValue(provider,
-                new CredentialsProfileProvider(CredentialsPK));
+                new TestCredentialsProfileProvider(CredentialsPK,
+                    profileTTL));
         }
 
         private IAMConfigInfo currentIAMConfig;
@@ -394,6 +409,170 @@ namespace Oracle.NoSQL.SDK.Tests.IAM
             }
             finally
             {
+                provider.Dispose();
+            }
+        }
+
+        [TestMethod]
+        public async Task TestDynamicDelegationTokenProviderCalledWithValidCacheAsync()
+        {
+            var providerCallCount = 0;
+            var provider =
+                IAMAuthorizationProvider.CreateWithInstancePrincipalForDelegation(
+                    cancellationToken =>
+                    {
+                        Interlocked.Increment(ref providerCallCount);
+                        return Task.FromResult(DelegationToken);
+                    });
+            provider.RefreshAhead = TimeSpan.Zero;
+
+            var client = new NoSQLClient(new NoSQLConfig
+            {
+                Region = TestRegion,
+                AuthorizationProvider = provider,
+                Compartment = CompartmentId
+            });
+            UseTestProfileProvider(provider);
+
+            var request = new GetTableRequest(client, "table", null);
+            var message1 = new HttpRequestMessage();
+            var message2 = new HttpRequestMessage();
+
+            try
+            {
+                await provider.ApplyAuthorizationAsync(request, message1,
+                    CancellationToken.None);
+                await provider.ApplyAuthorizationAsync(request, message2,
+                    CancellationToken.None);
+
+                Assert.AreEqual(2, providerCallCount);
+                VerifyAuthEqual(message2.Headers, message1.Headers,
+                    CredentialsKeyId, Keys.RSA, CompartmentId,
+                    DelegationToken);
+            }
+            finally
+            {
+                provider.Dispose();
+            }
+        }
+
+        [TestMethod]
+        public async Task TestDynamicDelegationTokenProviderDefaultRefreshAheadAsync()
+        {
+            var currentDelegationToken = DelegationToken;
+            var providerCallCount = 0;
+            var provider =
+                IAMAuthorizationProvider.CreateWithInstancePrincipalForDelegation(
+                    cancellationToken =>
+                    {
+                        Interlocked.Increment(ref providerCallCount);
+                        return Task.FromResult(currentDelegationToken);
+                    });
+            provider.CacheDuration = TimeSpan.FromSeconds(20);
+
+            var client = new NoSQLClient(new NoSQLConfig
+            {
+                Region = TestRegion,
+                AuthorizationProvider = provider,
+                Compartment = CompartmentId
+            });
+            UseTestProfileProvider(provider, TimeSpan.FromSeconds(11));
+
+            var request = new GetTableRequest(client, "table", null);
+            var message1 = new HttpRequestMessage();
+            var message2 = new HttpRequestMessage();
+            var updatedDelegationToken = DelegationToken + "-updated";
+
+            try
+            {
+                Assert.AreNotEqual(TimeSpan.Zero, provider.RefreshAhead);
+                await provider.ApplyAuthorizationAsync(request, message1,
+                    CancellationToken.None);
+                VerifyAuth(message1.Headers, CredentialsKeyId, Keys.RSA,
+                    CompartmentId, DelegationToken);
+
+                currentDelegationToken = updatedDelegationToken;
+                await Task.Delay(TimeSpan.FromMilliseconds(1500));
+                Assert.AreEqual(1, providerCallCount);
+
+                await provider.ApplyAuthorizationAsync(request, message2,
+                    CancellationToken.None);
+                Assert.AreEqual(2, providerCallCount);
+                VerifyAuth(message2.Headers, CredentialsKeyId, Keys.RSA,
+                    CompartmentId, updatedDelegationToken);
+            }
+            finally
+            {
+                provider.Dispose();
+            }
+        }
+
+        [TestMethod]
+        public async Task TestConcurrentDynamicDelegationTokensAsync()
+        {
+            var currentDelegationToken = new AsyncLocal<string>();
+            var providerCallCount = 0;
+            var providerCallsStarted = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var provider =
+                IAMAuthorizationProvider.CreateWithInstancePrincipalForDelegation(
+                    async cancellationToken =>
+                    {
+                        if (Interlocked.Increment(ref providerCallCount) == 2)
+                        {
+                            providerCallsStarted.TrySetResult(true);
+                        }
+
+                        await providerCallsStarted.Task;
+                        return currentDelegationToken.Value;
+                    });
+            provider.RefreshAhead = TimeSpan.Zero;
+
+            var client = new NoSQLClient(new NoSQLConfig
+            {
+                Region = TestRegion,
+                AuthorizationProvider = provider,
+                Compartment = CompartmentId
+            });
+            UseTestProfileProvider(provider);
+
+            var request = new GetTableRequest(client, "table", null);
+            var aliceToken = DelegationToken + "-alice";
+            var bobToken = DelegationToken + "-bob";
+
+            async Task<HttpRequestMessage> ApplyWithToken(string token)
+            {
+                currentDelegationToken.Value = token;
+                var message = new HttpRequestMessage();
+                await provider.ApplyAuthorizationAsync(request, message,
+                    CancellationToken.None);
+                return message;
+            }
+
+            try
+            {
+                var aliceTask = Task.Run(() => ApplyWithToken(aliceToken));
+                var bobTask = Task.Run(() => ApplyWithToken(bobToken));
+                var allTasks = Task.WhenAll(aliceTask, bobTask);
+
+                if (await Task.WhenAny(allTasks,
+                    Task.Delay(TimeSpan.FromSeconds(5))) != allTasks)
+                {
+                    providerCallsStarted.TrySetResult(true);
+                    Assert.Fail("Timed out waiting for concurrent " +
+                                "delegation token requests");
+                }
+
+                var messages = await allTasks;
+                Assert.AreEqual(2, providerCallCount);
+                VerifyAuth(messages[0].Headers, CredentialsKeyId, Keys.RSA,
+                    CompartmentId, aliceToken);
+                VerifyAuth(messages[1].Headers, CredentialsKeyId, Keys.RSA,
+                    CompartmentId, bobToken);
+            }
+            finally
+            {
+                providerCallsStarted.TrySetResult(true);
                 provider.Dispose();
             }
         }


### PR DESCRIPTION
Summary: Prevents delegated-user token providers/files from being cached across unrelated requests, keeping authentication state scoped to the intended request context.\n\nTesting: split branch cherry-picked cleanly from origin/main. Please run repository CI for full validation.