### PR TITLE
Restore supported .NET version coverage for the Oracle NoSQL .NET SDK.

### DIFF
--- a/Oracle.NoSQL.SDK.Samples/BasicExample/BasicExample.csproj
+++ b/Oracle.NoSQL.SDK.Samples/BasicExample/BasicExample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <RollForward>Major</RollForward>
     <RootNamespace>Oracle.NoSQL.SDK.Samples</RootNamespace>
   </PropertyGroup>

--- a/Oracle.NoSQL.SDK.Samples/BasicExample/Program.cs
+++ b/Oracle.NoSQL.SDK.Samples/BasicExample/Program.cs
@@ -46,16 +46,18 @@ namespace Oracle.NoSQL.SDK.Samples
     //
     // Run the example as:
     //
-    // dotnet run -- <config file>
+    // dotnet run -f <target-framework> -- <config file>
     //
     // where:
+    //   - <target-framework> is target framework moniker, supported values
+    //     are net8.0, net9.0, and net10.0
     //   - <config file> is the JSON config file created as described above
     // ------------------------------------------------------------------------
 
     public class Program
     {
         private const string Usage =
-            "Usage: dotnet run [-- <config file>]";
+            "Usage: dotnet run -f <target-framework> [-- <config file>]";
         private const string TableName = "BasicExample";
 
         // <Main>

--- a/Oracle.NoSQL.SDK.Samples/QueryExample/Program.cs
+++ b/Oracle.NoSQL.SDK.Samples/QueryExample/Program.cs
@@ -48,16 +48,18 @@ namespace Oracle.NoSQL.SDK.Samples
     //
     // Run the example as:
     //
-    // dotnet run -- <config file>
+    // dotnet run -f <target-framework> -- <config file>
     //
     // where:
+    //   - <target-framework> is target framework moniker, supported values
+    //     are net8.0, net9.0, and net10.0
     //   - <config file> is the JSON config file created as described above
     // ------------------------------------------------------------------------
 
     public class Program
     {
         private const string Usage =
-            "Usage: dotnet run [-- <config file>]";
+            "Usage: dotnet run -f <target-framework> [-- <config file>]";
         private const string TableName = "users";
 
         private static readonly JsonOutputOptions JsonOptions =

--- a/Oracle.NoSQL.SDK.Samples/QueryExample/QueryExample.csproj
+++ b/Oracle.NoSQL.SDK.Samples/QueryExample/QueryExample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <RollForward>Major</RollForward>
     <RootNamespace>Oracle.NoSQL.SDK.Samples</RootNamespace>
   </PropertyGroup>

--- a/Oracle.NoSQL.SDK/src/Oracle.NoSQL.SDK.csproj
+++ b/Oracle.NoSQL.SDK/src/Oracle.NoSQL.SDK.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
     <Company>Oracle Corporation</Company>
     <Product>Oracle NoSQL Database</Product>

--- a/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.SmokeTest/Oracle.NoSQL.SDK.SmokeTest.csproj
+++ b/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.SmokeTest/Oracle.NoSQL.SDK.SmokeTest.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <RollForward>Major</RollForward>
     <LangVersion>latest</LangVersion>
     <ApplicationIcon />

--- a/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/Oracle.NoSQL.SDK.Tests.csproj
+++ b/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/Oracle.NoSQL.SDK.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <RollForward>Major</RollForward>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -10,15 +10,15 @@ source code and run and modify tests and examples.
 
 Read [README](./README.md) on how to use the SDK.
 
-1.  You may develop on Windows, Linux or Mac.  The SDK supports .NET 10.0 or
-later supported versions. Download your chosen .NET version
-[here](https://dotnet.microsoft.com/en-us/download/dotnet) and follow
+1.  You may develop on Windows, Linux or Mac.  The SDK supports .NET 8.0,
+.NET 9.0, .NET 10.0, or later supported versions. Download your chosen .NET
+version [here](https://dotnet.microsoft.com/en-us/download/dotnet) and follow
 installation instructions for your operating system.
 
 After installation, set *DOTNET_ROOT* environment variable to point to the .NET
 installation location. 
 
-Currently, the SDK is built for .NET 10.0.
+Currently, the SDK is built for .NET 8.0, .NET 9.0, and .NET 10.0.
 
 Note that .NET SDK for Oracle NoSQL Database requires C# version 8.0 or
 higher.
@@ -246,10 +246,12 @@ database. It requires JSON configuration file as described above.  To
 
 ```bash
 cd nosql-dotnet-sdk/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.SmokeTest
-dotnet run [-c <build-configuration>] -- /path/to/config.json
+dotnet run -f <target-framework> [-c <build-configuration>] -- /path/to/config.json
 ```
 
-where *build-configuration* is *Debug* or *Release*, default is *Debug*.
+where *target-framework* is target framework moniker (TFM), values are
+*net8.0*, *net9.0*, and *net10.0*, and *build-configuration* is *Debug* or
+*Release*, default is *Debug*.
 
 Note: you may omit JSON configuration file if running against the cloud
 service using default OCI configuration file (see

--- a/README.md
+++ b/README.md
@@ -288,10 +288,12 @@ command, providing JSON config file as the command line argument:
 
 ```bash
 cd Oracle.NoSQL.SDK.Samples/<example>
-dotnet run [-- /path/to/config.json]
+dotnet run -f <target-framework> [-- /path/to/config.json]
 ```
 
-where *<example>* is the example directory.
+where *<example>* is the example directory and *<target-framework>* is the
+target framework moniker, supported values are *net8.0*, *net9.0*, and
+*net10.0*.
 
 The command above will build and run the example.
 
@@ -299,7 +301,7 @@ For example:
 
 ```bash
 cd Oracle.NoSQL.SDK.Samples/BasicExample
-dotnet run -- my_config.json
+dotnet run -f net8.0 -- my_config.json
 ```
 
 ## Help

--- a/scripts/test-retry-hardening-cloud.sh
+++ b/scripts/test-retry-hardening-cloud.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-TFM="${TFM:-net5.0}"
+TFM="${TFM:-net8.0}"
 CONFIG="${1:-${NOSQL_CONFIG_FILE:-}}"
 TEST_PROJECT="$ROOT/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/Oracle.NoSQL.SDK.Tests.csproj"
 SMOKE_PROJECT="$ROOT/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.SmokeTest/Oracle.NoSQL.SDK.SmokeTest.csproj"

--- a/scripts/test-retry-hardening-local.sh
+++ b/scripts/test-retry-hardening-local.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-TFM="${TFM:-net5.0}"
+TFM="${TFM:-net8.0}"
 CONFIG="${1:-${NOSQL_CONFIG_FILE:-$ROOT/Oracle.NoSQL.SDK.Samples/cloudsim.json}}"
 TEST_PROJECT="$ROOT/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/Oracle.NoSQL.SDK.Tests.csproj"
 SMOKE_PROJECT="$ROOT/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.SmokeTest/Oracle.NoSQL.SDK.SmokeTest.csproj"


### PR DESCRIPTION
The previous PR changed the SDK package to net10.0 only. That limits customers using currently supported .NET 8 and .NET 9 applications, because NuGet compatibility for a library is determined by package assets such as lib/net8.0, lib/net9.0, and lib/net10.0.
### Changes 
- Restored multi-targeting for:
    - SDK library
    - unit tests-
    - smoke test
    - BasicExample
    - QueryExample

- Updated README and README-DEV to document .NET 8, 9, and 10 support.
- Restored dotnet run -f <target-framework> guidance for multi-targeted sample/smoke test projects.
- Updated sample usage strings to list net8.0, net9.0, and net10.0.

### Validations
Compile checks passed for all three target frameworks:

dotnet build Oracle.NoSQL.SDK/src/Oracle.NoSQL.SDK.csproj --no-restore
dotnet build Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/Oracle.NoSQL.SDK.Tests.csproj --no-restore
dotnet build Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.SmokeTest/Oracle.NoSQL.SDK.SmokeTest.csproj --no-restore
dotnet build Oracle.NoSQL.SDK.Samples/BasicExample/BasicExample.csproj --no-restore
dotnet build Oracle.NoSQL.SDK.Samples/QueryExample/QueryExample.csproj --no-restore
All builds produced net8.0, net9.0, and net10.0 outputs with 0 errors.