### PR TITLE
Use CreateFromPem for IAM certificate parsing

### DIFF
--- a/Oracle.NoSQL.SDK/src/Auth/IAM/Utils.cs
+++ b/Oracle.NoSQL.SDK/src/Auth/IAM/Utils.cs
@@ -59,7 +59,7 @@ namespace Oracle.NoSQL.SDK {
         }
 
         internal static X509Certificate2 GetCertificateFromPEM(string pem) =>
-            new X509Certificate2(Encoding.UTF8.GetBytes(pem));
+            X509Certificate2.CreateFromPem(pem);
 
         // Taken from C# OCI SDK
         internal static string GetTenantIdFromInstanceCertificate(


### PR DESCRIPTION
- This change updates IAM certificate parsing to use X509Certificate2.CreateFromPem(pem) instead of constructing X509Certificate2 from UTF-8 PEM bytes.
- CreateFromPem is the .NET API intended for PEM-formatted certificate material and avoids relying on byte-array certificate loading behavior.
