### PR TITLE
Expose last-write metadata on WriteRequest

### DIFF
--- a/Oracle.NoSQL.SDK/src/Options/IOptions.cs
+++ b/Oracle.NoSQL.SDK/src/Options/IOptions.cs
@@ -34,6 +34,8 @@ namespace Oracle.NoSQL.SDK
     {
         Durability? Durability { get; }
 
+        string LastWriteMetadata { get; }
+
         bool ReturnExisting { get; }
     }
 

--- a/Oracle.NoSQL.SDK/src/Request/DeleteRequest.cs
+++ b/Oracle.NoSQL.SDK/src/Request/DeleteRequest.cs
@@ -96,7 +96,7 @@ namespace Oracle.NoSQL.SDK
         /// <summary>
         /// Gets the JSON last-write metadata for the Delete operation.
         /// </summary>
-        public string LastWriteMetadata => Options?.LastWriteMetadata;
+        public new string LastWriteMetadata => base.LastWriteMetadata;
 
         bool ILastWriteMetadataRequest.HasLastWriteMetadata =>
             LastWriteMetadata != null;

--- a/Oracle.NoSQL.SDK/src/Request/PutRequest.cs
+++ b/Oracle.NoSQL.SDK/src/Request/PutRequest.cs
@@ -100,7 +100,7 @@ namespace Oracle.NoSQL.SDK
         /// <summary>
         /// Gets the JSON last-write metadata for the Put operation.
         /// </summary>
-        public string LastWriteMetadata => Options?.LastWriteMetadata;
+        public new string LastWriteMetadata => base.LastWriteMetadata;
 
         bool ILastWriteMetadataRequest.HasLastWriteMetadata =>
             LastWriteMetadata != null;

--- a/Oracle.NoSQL.SDK/src/Request/RequestWithTable.cs
+++ b/Oracle.NoSQL.SDK/src/Request/RequestWithTable.cs
@@ -104,6 +104,14 @@ namespace Oracle.NoSQL.SDK
 
         internal Durability? Durability => WriteOptions?.Durability;
 
+        /// <summary>
+        /// Gets the JSON last-write metadata for the write operation.
+        /// </summary>
+        /// <value>
+        /// The JSON metadata, or <c>null</c> if metadata was not provided.
+        /// </value>
+        public string LastWriteMetadata => WriteOptions?.LastWriteMetadata;
+
         internal override bool SupportsRateLimiting => true;
 
         internal override bool DoesWrites => true;

--- a/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/RowMetadataValidationTests.cs
+++ b/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/RowMetadataValidationTests.cs
@@ -93,6 +93,42 @@ namespace Oracle.NoSQL.SDK.Tests
         }
 
         [TestMethod]
+        public void TestWriteRequestExposesPutLastWriteMetadata()
+        {
+            using var client = MakeClient();
+            const string metadata = "{\"operation\":\"put\"}";
+            var options = new PutOptions
+            {
+                LastWriteMetadata = metadata
+            };
+            var putRequest = new PutRequest<RecordValue>(client, "users",
+                new MapValue(), options);
+            WriteRequest writeRequest = putRequest;
+
+            Assert.AreEqual(metadata, writeRequest.LastWriteMetadata);
+            Assert.AreEqual(putRequest.LastWriteMetadata,
+                writeRequest.LastWriteMetadata);
+        }
+
+        [TestMethod]
+        public void TestWriteRequestExposesDeleteLastWriteMetadata()
+        {
+            using var client = MakeClient();
+            const string metadata = "{\"operation\":\"delete\"}";
+            var options = new DeleteOptions
+            {
+                LastWriteMetadata = metadata
+            };
+            var deleteRequest = new DeleteRequest<RecordValue>(client,
+                "users", new MapValue(), options);
+            WriteRequest writeRequest = deleteRequest;
+
+            Assert.AreEqual(metadata, writeRequest.LastWriteMetadata);
+            Assert.AreEqual(deleteRequest.LastWriteMetadata,
+                writeRequest.LastWriteMetadata);
+        }
+
+        [TestMethod]
         public void TestEnabledFeaturesParsing()
         {
             Assert.IsNull(GetEnabledFeatures(null));


### PR DESCRIPTION
## Summary

- Add public read-only `WriteRequest.LastWriteMetadata`, backed by the shared `IWriteOptions` contract.
- Keep the existing Put and Delete getters as explicit forwarding members for binary/API compatibility.
- Add tests proving metadata is available when Put and Delete requests are referenced polymorphically as `WriteRequest`.

## Validation

- `dotnet build Oracle.NoSQL.SDK.sln -c Release --no-restore`: succeeded with 0 warnings and 0 errors.
- Focused unit and on-prem metadata tests: 12/12 passed on each of net8.0, net9.0, and net10.0 against KVStore at localhost:8080.
- net10.0 on-prem smoke test: passed end-to-end.

## Full-suite note

A full all-framework on-prem run was attempted. Running all TFMs together caused known shared-resource collisions between test assemblies. A serial net8.0 retry later encountered unrelated server-side 10-second timeouts in global-active-table cleanup and index setup, then stopped making progress and was cancelled. The changed and related metadata suites remain green across all supported TFMs.