### PR TITLE
Add system-generated creation time support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 **Added**
 * Latest OCI region codes
+* Added server-generated creation-time metadata to Get, Put, Delete, and
+  WriteMany results when returned by the service.
 
 ## [5.2.3]
 

--- a/Oracle.NoSQL.SDK/src/NoSQLClient.Data.cs
+++ b/Oracle.NoSQL.SDK/src/NoSQLClient.Data.cs
@@ -133,11 +133,12 @@ namespace Oracle.NoSQL.SDK {
         /// It is also possible to return information about the existing row.
         /// The row, including its <see cref="RowVersion"/>, creation time,
         /// and modification time can be optionally returned as part of
-        /// <see cref="PutResult{TRow}"/> via properties
+        /// <see cref="PutResult{TRow}"/> via the
         /// <see cref="PutResult{TRow}.ExistingRow"/>,
-        /// <see cref="PutResult{TRow}.ExistingVersion"/> and
+        /// <see cref="PutResult{TRow}.ExistingVersion"/>,
         /// <see cref="PutResult{TRow}.ExistingCreationTime"/>,
-        /// <see cref="PutResult{TRow}.ExistingModificationTime"/>. The
+        /// and <see cref="PutResult{TRow}.ExistingModificationTime"/>
+        /// properties. The
         /// existing row information will only be returned if
         /// <see cref="PutOptions.ReturnExisting"/> is <c>true</c> and one of
         /// the following occurs:

--- a/Oracle.NoSQL.SDK/src/NoSQLClient.Data.cs
+++ b/Oracle.NoSQL.SDK/src/NoSQLClient.Data.cs
@@ -131,11 +131,12 @@ namespace Oracle.NoSQL.SDK {
         /// </para>
         /// <para>
         /// It is also possible to return information about the existing row.
-        /// The row, including its <see cref="RowVersion"/> and modification
-        /// time can be optionally returned as part of
+        /// The row, including its <see cref="RowVersion"/>, creation time,
+        /// and modification time can be optionally returned as part of
         /// <see cref="PutResult{TRow}"/> via properties
         /// <see cref="PutResult{TRow}.ExistingRow"/>,
         /// <see cref="PutResult{TRow}.ExistingVersion"/> and
+        /// <see cref="PutResult{TRow}.ExistingCreationTime"/>,
         /// <see cref="PutResult{TRow}.ExistingModificationTime"/>. The
         /// existing row information will only be returned if
         /// <see cref="PutOptions.ReturnExisting"/> is <c>true</c> and one of

--- a/Oracle.NoSQL.SDK/src/NoSQLClient.Data.cs
+++ b/Oracle.NoSQL.SDK/src/NoSQLClient.Data.cs
@@ -394,11 +394,14 @@ namespace Oracle.NoSQL.SDK {
         /// </para>
         /// <para>
         /// It is also possible to return information about the existing row.
-        /// The row, its version and modification time can be optionally
-        /// returned as part of <see cref="DeleteResult{TRow}"/> via
-        /// properties <see cref="DeleteResult{TRow}.ExistingRow"/>,
-        /// <see cref="DeleteResult{TRow}.ExistingVersion"/> and
-        /// <see cref="DeleteResult{TRow}.ExistingModificationTime"/>. The
+        /// The row, including its <see cref="RowVersion"/>, creation time,
+        /// and modification time can be optionally returned as part of
+        /// <see cref="DeleteResult{TRow}"/> via the
+        /// <see cref="DeleteResult{TRow}.ExistingRow"/>,
+        /// <see cref="DeleteResult{TRow}.ExistingVersion"/>,
+        /// <see cref="DeleteResult{TRow}.ExistingCreationTime"/>,
+        /// and <see cref="DeleteResult{TRow}.ExistingModificationTime"/>
+        /// properties. The
         /// existing row information will only be returned if
         /// <see cref="DeleteOptions.ReturnExisting"/> is <c>true</c> and one
         /// of the following occurs:

--- a/Oracle.NoSQL.SDK/src/NoSQLClient.Data.cs
+++ b/Oracle.NoSQL.SDK/src/NoSQLClient.Data.cs
@@ -21,7 +21,9 @@ namespace Oracle.NoSQL.SDK {
         /// <see cref="GetResult{TRow}.Row"/> property. If matching row
         /// does not exist, the operation is still successful and
         /// <see cref="GetResult{TRow}.Row"/> property will be set to
-        /// <c>null</c>.
+        /// <c>null</c>.  If the row exists and the service provides it, its
+        /// system-generated creation time is available through
+        /// <see cref="GetResult{TRow}.CreationTime"/>.
         /// </remarks>
         /// <example>
         /// Executing Get operation on table with schema MyTable(id LONG,

--- a/Oracle.NoSQL.SDK/src/NsonProtocol/Protocol.Reader.cs
+++ b/Oracle.NoSQL.SDK/src/NsonProtocol/Protocol.Reader.cs
@@ -297,6 +297,10 @@ namespace Oracle.NoSQL.SDK.NsonProtocol
             {
                 switch (field)
                 {
+                    case FieldNames.CreationTime:
+                        result.ExistingCreationTime =
+                            ReadOptionalTimestamp(reader);
+                        return true;
                     case FieldNames.ExistingModTime:
                         result.ExistingModificationTime =
                             ReadOptionalTimestamp(reader);

--- a/Oracle.NoSQL.SDK/src/NsonProtocol/Protocol.cs
+++ b/Oracle.NoSQL.SDK/src/NsonProtocol/Protocol.cs
@@ -123,6 +123,7 @@ namespace Oracle.NoSQL.SDK.NsonProtocol
             // row metadata
             internal const string Row = "r";
             internal const string RowVersion = "rv";
+            internal const string CreationTime = "ct";
             internal const string ExpirationTime = "xp";
             internal const string ModificationTime = "md";
 

--- a/Oracle.NoSQL.SDK/src/NsonProtocol/RequestSerializer.Data.cs
+++ b/Oracle.NoSQL.SDK/src/NsonProtocol/RequestSerializer.Data.cs
@@ -139,6 +139,10 @@ namespace Oracle.NoSQL.SDK.NsonProtocol
                         case FieldNames.RowVersion:
                             result.Version = ReadRowVersion(reader);
                             return true;
+                        case FieldNames.CreationTime:
+                            result.CreationTime =
+                                ReadOptionalTimestamp(reader);
+                            return true;
                         case FieldNames.ExpirationTime:
                             result.ExpirationTime =
                                 ReadOptionalTimestamp(reader);

--- a/Oracle.NoSQL.SDK/src/Result/DeleteResult.cs
+++ b/Oracle.NoSQL.SDK/src/Result/DeleteResult.cs
@@ -68,6 +68,12 @@ namespace Oracle.NoSQL.SDK
             set => ExistingVersion = value;
         }
 
+        DateTime? IWriteResult<TRow>.ExistingCreationTime
+        {
+            get => ExistingCreationTime;
+            set => ExistingCreationTime = value;
+        }
+
         DateTime? IWriteResult<TRow>.ExistingModificationTime
         {
             get => ExistingModificationTime;
@@ -120,6 +126,18 @@ namespace Oracle.NoSQL.SDK
         /// <seealso cref="NoSQLClient.DeleteAsync"/>
         /// <seealso cref="DeleteOptions.ReturnExisting"/>
         public RowVersion ExistingVersion { get; internal set; }
+
+        /// <summary>
+        /// Gets the creation time of existing row if available.
+        /// </summary>
+        /// <inheritdoc cref="ExistingRow" path="remarks"/>
+        /// <value>
+        /// The creation time of existing row in UTC if available, otherwise
+        /// <c>null</c>.
+        /// </value>
+        /// <seealso cref="NoSQLClient.DeleteAsync"/>
+        /// <seealso cref="DeleteOptions.ReturnExisting"/>
+        public DateTime? ExistingCreationTime { get; internal set; }
 
         /// <summary>
         /// Gets the JSON last-write metadata of existing row if available.

--- a/Oracle.NoSQL.SDK/src/Result/GetResult.cs
+++ b/Oracle.NoSQL.SDK/src/Result/GetResult.cs
@@ -71,6 +71,16 @@ namespace Oracle.NoSQL.SDK
         public DateTime? ExpirationTime { get; internal set; }
 
         /// <summary>
+        /// Gets the system-generated creation time of the row.
+        /// </summary>
+        /// <value>
+        /// Creation time of the row in UTC if available from the server, or
+        /// <c>null</c> if the row does not exist or the server does not
+        /// provide this value.
+        /// </value>
+        public DateTime? CreationTime { get; internal set; }
+
+        /// <summary>
         /// Gets the modification time of the row.
         /// </summary>
         /// <value>

--- a/Oracle.NoSQL.SDK/src/Result/IResult.cs
+++ b/Oracle.NoSQL.SDK/src/Result/IResult.cs
@@ -22,6 +22,8 @@ namespace Oracle.NoSQL.SDK
 
         RowVersion ExistingVersion { get; set; }
 
+        DateTime? ExistingCreationTime { get; set; }
+
         DateTime? ExistingModificationTime { get; set; }
 
         string ExistingLastWriteMetadata { get; set; }

--- a/Oracle.NoSQL.SDK/src/Result/PutResult.cs
+++ b/Oracle.NoSQL.SDK/src/Result/PutResult.cs
@@ -70,6 +70,12 @@ namespace Oracle.NoSQL.SDK
             set => ExistingVersion = value;
         }
 
+        DateTime? IWriteResult<TRow>.ExistingCreationTime
+        {
+            get => ExistingCreationTime;
+            set => ExistingCreationTime = value;
+        }
+
         DateTime? IWriteResult<TRow>.ExistingModificationTime
         {
             get => ExistingModificationTime;
@@ -148,6 +154,18 @@ namespace Oracle.NoSQL.SDK
         /// <seealso cref="NoSQLClient.PutAsync"/>
         /// <seealso cref="PutOptions.ReturnExisting"/>
         public RowVersion ExistingVersion { get; internal set; }
+
+        /// <summary>
+        /// Gets the creation time of existing row.
+        /// </summary>
+        /// <inheritdoc cref="ExistingRow" path="remarks"/>
+        /// <value>
+        /// The creation time of existing row in UTC if available, otherwise
+        /// <c>null</c>.
+        /// </value>
+        /// <seealso cref="NoSQLClient.PutAsync"/>
+        /// <seealso cref="PutOptions.ReturnExisting"/>
+        public DateTime? ExistingCreationTime { get; internal set; }
 
         /// <summary>
         /// Gets the modification time of existing row.

--- a/Oracle.NoSQL.SDK/src/Result/WriteManyResult.cs
+++ b/Oracle.NoSQL.SDK/src/Result/WriteManyResult.cs
@@ -27,6 +27,11 @@ namespace Oracle.NoSQL.SDK
     /// <see cref="WriteOperationResult{TRow}"/>.
     /// </para>
     /// <para>
+    /// For a Put or Delete sub operation configured to return an existing
+    /// row, its result may also include the server-generated creation time in
+    /// <see cref="WriteOperationResult{TRow}.ExistingCreationTime"/>.
+    /// </para>
+    /// <para>
     /// If the operation is aborted because of the failure of a Put or Delete
     /// sub operation that has
     /// <see cref="IWriteOperation.AbortIfUnsuccessful"/> set to <c>true</c>

--- a/Oracle.NoSQL.SDK/src/Result/WriteOperationResult.cs
+++ b/Oracle.NoSQL.SDK/src/Result/WriteOperationResult.cs
@@ -51,6 +51,12 @@ namespace Oracle.NoSQL.SDK
             set => ExistingVersion = value;
         }
 
+        DateTime? IWriteResult<TRow>.ExistingCreationTime
+        {
+            get => ExistingCreationTime;
+            set => ExistingCreationTime = value;
+        }
+
         DateTime? IWriteResult<TRow>.ExistingModificationTime
         {
             get => ExistingModificationTime;
@@ -136,6 +142,21 @@ namespace Oracle.NoSQL.SDK
         /// <seealso cref="PutResult{TRow}.ExistingLastWriteMetadata"/>
         /// <seealso cref="DeleteResult{TRow}.ExistingLastWriteMetadata"/>
         public string ExistingLastWriteMetadata { get; internal set; }
+
+        /// <summary>
+        /// Gets the creation time of existing row if the Put or Delete
+        /// operation returned it.
+        /// </summary>
+        /// <remarks>
+        /// This value is equivalent to
+        /// <see cref="PutResult{TRow}.ExistingCreationTime"/> or
+        /// <see cref="DeleteResult{TRow}.ExistingCreationTime"/> for Put and
+        /// Delete operations respectively.
+        /// </remarks>
+        /// <inheritdoc cref="PutResult{TRow}.ExistingCreationTime" path="value"/>
+        /// <seealso cref="PutResult{TRow}.ExistingCreationTime"/>
+        /// <seealso cref="DeleteResult{TRow}.ExistingCreationTime"/>
+        public DateTime? ExistingCreationTime { get; internal set; }
 
         /// <summary>
         /// Gets the modification time of existing row if the conditional Put

--- a/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/CreationTimeProtocolTests.cs
+++ b/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/CreationTimeProtocolTests.cs
@@ -1,0 +1,130 @@
+/*-
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ *  https://oss.oracle.com/licenses/upl/
+ */
+
+namespace Oracle.NoSQL.SDK.Tests
+{
+    using System;
+    using System.IO;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using NsonProtocol;
+
+    [TestClass]
+    public class CreationTimeProtocolTests
+    {
+        private const long CreationTimeMillis = 1786513124792;
+
+        [TestMethod]
+        public void TestGetDeserializesCreationTime()
+        {
+            using var client = MakeClient();
+            var request = new GetRequest<RecordValue>(client, "table",
+                new MapValue(), null);
+            using var stream = CreateResponse(writer =>
+            {
+                writer.StartMap(Protocol.FieldNames.Row);
+                writer.WriteInt64(Protocol.FieldNames.CreationTime,
+                    CreationTimeMillis);
+                writer.EndMap();
+            });
+
+            var result = new RequestSerializer().DeserializeGet(stream,
+                request);
+
+            Assert.AreEqual(GetCreationTime(), result.CreationTime);
+        }
+
+        [TestMethod]
+        public void TestGetTreatsMissingAndZeroCreationTimeAsUnavailable()
+        {
+            using var client = MakeClient();
+            var request = new GetRequest<RecordValue>(client, "table",
+                new MapValue(), null);
+
+            using var missingStream = CreateResponse(_ => { });
+            var missingResult = new RequestSerializer().DeserializeGet(
+                missingStream, request);
+            Assert.IsNull(missingResult.CreationTime);
+
+            using var zeroStream = CreateResponse(writer =>
+            {
+                writer.StartMap(Protocol.FieldNames.Row);
+                writer.WriteInt64(Protocol.FieldNames.CreationTime, 0);
+                writer.EndMap();
+            });
+            var zeroResult = new RequestSerializer().DeserializeGet(
+                zeroStream, request);
+            Assert.IsNull(zeroResult.CreationTime);
+        }
+
+        [TestMethod]
+        public void TestReturnInfoDeserializesCreationTimeForAllWriteResults()
+        {
+            var putResult = new PutResult<RecordValue>();
+            var deleteResult = new DeleteResult<RecordValue>();
+            var operationResult = new WriteOperationResult<RecordValue>();
+
+            DeserializeReturnInfo(putResult, CreationTimeMillis);
+            DeserializeReturnInfo(deleteResult, CreationTimeMillis);
+            DeserializeReturnInfo(operationResult, CreationTimeMillis);
+
+            var expected = GetCreationTime();
+            Assert.AreEqual(expected, putResult.ExistingCreationTime);
+            Assert.AreEqual(expected, deleteResult.ExistingCreationTime);
+            Assert.AreEqual(expected, operationResult.ExistingCreationTime);
+        }
+
+        [TestMethod]
+        public void TestReturnInfoTreatsMissingAndZeroCreationTimeAsUnavailable()
+        {
+            var missingResult = new PutResult<RecordValue>();
+            DeserializeReturnInfo(missingResult, null);
+            Assert.IsNull(missingResult.ExistingCreationTime);
+
+            var zeroResult = new PutResult<RecordValue>();
+            DeserializeReturnInfo(zeroResult, 0);
+            Assert.IsNull(zeroResult.ExistingCreationTime);
+        }
+
+        private static NoSQLClient MakeClient() => new NoSQLClient(
+            new NoSQLConfig
+            {
+                ServiceType = ServiceType.CloudSim,
+                Endpoint = "localhost:8080"
+            });
+
+        private static MemoryStream CreateResponse(Action<NsonWriter> write)
+        {
+            var stream = new MemoryStream();
+            var writer = Protocol.GetNsonWriter(stream);
+            writer.StartMap();
+            write(writer);
+            writer.EndMap();
+            stream.Position = 0;
+            return stream;
+        }
+
+        private static void DeserializeReturnInfo(IWriteResult<RecordValue> result,
+            long? creationTime)
+        {
+            using var stream = CreateResponse(writer =>
+            {
+                if (creationTime.HasValue)
+                {
+                    writer.WriteInt64(Protocol.FieldNames.CreationTime,
+                        creationTime.Value);
+                }
+            });
+
+            var reader = Protocol.GetNsonReader(stream);
+            reader.Next();
+            Protocol.DeserializeReturnInfo(reader, result);
+        }
+
+        private static DateTime GetCreationTime() =>
+            DateTime.UnixEpoch.AddMilliseconds(CreationTimeMillis);
+    }
+}

--- a/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/CreationTimeTests.cs
+++ b/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/CreationTimeTests.cs
@@ -1,0 +1,185 @@
+/*-
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ *  https://oss.oracle.com/licenses/upl/
+ */
+
+namespace Oracle.NoSQL.SDK.Tests
+{
+    using System;
+    using System.Threading.Tasks;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using static TestSchemas;
+    using static TestTables;
+
+    [TestClass]
+    public class CreationTimeTests : DataTestBase<CreationTimeTests>
+    {
+        private const int ShardId = 1;
+
+        private static readonly Version CreationTimeVersion =
+            new Version("25.3");
+
+        private static readonly TableInfo Table = new TableInfo(
+            TableNamePrefix + "CreationTime" +
+            Guid.NewGuid().ToString("N").Substring(0, 8),
+            DefaultTableLimits,
+            new[]
+            {
+                new TableField("sid", DataType.Integer),
+                new TableField("id", DataType.Integer),
+                new TableField("name", DataType.String)
+            },
+            new[] { "sid", "id" },
+            1);
+
+        [ClassInitialize]
+        public static async Task ClassInitializeAsync(TestContext testContext)
+        {
+            ClassInitialize(testContext);
+        }
+
+        [ClassCleanup]
+        public static async Task ClassCleanupAsync()
+        {
+            await DropTableAsync(Table);
+            ClassCleanup();
+        }
+
+        [TestInitialize]
+        public async Task TestInitializeAsync()
+        {
+            CheckCreationTimeSupport();
+            await DropTableAsync(Table);
+            await CreateTableAsync(Table);
+        }
+
+        [TestMethod]
+        public async Task TestGetCreationTimeIsServerGeneratedAndImmutableAsync()
+        {
+            await client.PutAsync(Table.Name, CreateRow(0));
+            var initialResult = await GetRowAsync(0);
+            var creationTime = GetRequiredCreationTime(initialResult);
+
+            Assert.AreEqual(DateTimeKind.Utc, creationTime.Kind);
+            Assert.IsNotNull(initialResult.ModificationTime);
+            Assert.IsTrue(creationTime <= initialResult.ModificationTime);
+
+            var putResult = await client.PutAsync(Table.Name,
+                CreateRow(0, "updated"), new PutOptions
+                {
+                    ReturnExisting = true
+                });
+
+            Assert.IsTrue(putResult.Success);
+            Assert.AreEqual(creationTime, putResult.ExistingCreationTime);
+
+            var updatedResult = await GetRowAsync(0);
+            Assert.AreEqual(creationTime, updatedResult.CreationTime);
+            Assert.IsNotNull(updatedResult.ModificationTime);
+            Assert.IsTrue(creationTime <= updatedResult.ModificationTime);
+
+            var missingResult = await GetRowAsync(100);
+            Assert.IsNull(missingResult.Row);
+            Assert.IsNull(missingResult.CreationTime);
+        }
+
+        [TestMethod]
+        public async Task TestPutAndDeleteReturnExistingCreationTimeAsync()
+        {
+            await client.PutAsync(Table.Name, CreateRow(0));
+            var creationTime = GetRequiredCreationTime(await GetRowAsync(0));
+
+            var conditionalPutResult = await client.PutIfAbsentAsync(
+                Table.Name, CreateRow(0, "ignored"), new PutOptions
+                {
+                    ReturnExisting = true
+                });
+
+            Assert.IsFalse(conditionalPutResult.Success);
+            Assert.AreEqual(creationTime,
+                conditionalPutResult.ExistingCreationTime);
+
+            var deleteResult = await client.DeleteAsync(Table.Name,
+                CreateKey(0), new DeleteOptions
+                {
+                    ReturnExisting = true
+                });
+
+            Assert.IsTrue(deleteResult.Success);
+            Assert.AreEqual(creationTime, deleteResult.ExistingCreationTime);
+
+            var newRowResult = await client.PutAsync(Table.Name, CreateRow(1),
+                new PutOptions
+                {
+                    ReturnExisting = true
+                });
+            Assert.IsTrue(newRowResult.Success);
+            Assert.IsNull(newRowResult.ExistingCreationTime);
+        }
+
+        [TestMethod]
+        public async Task TestWriteManyReturnsExistingCreationTimeAsync()
+        {
+            await client.PutAsync(Table.Name, CreateRow(0));
+            await client.PutAsync(Table.Name, CreateRow(1));
+            var firstCreationTime = GetRequiredCreationTime(
+                await GetRowAsync(0));
+            var secondCreationTime = GetRequiredCreationTime(
+                await GetRowAsync(1));
+
+            var result = await client.WriteManyAsync(Table.Name,
+                new WriteOperationCollection()
+                    .AddPutIfPresent(CreateRow(0, "updated"),
+                        new PutOptions { ReturnExisting = true })
+                    .AddDelete(CreateKey(1),
+                        new DeleteOptions { ReturnExisting = true }));
+
+            Assert.IsTrue(result.Success);
+            Assert.AreEqual(2, result.Results.Count);
+            Assert.AreEqual(firstCreationTime,
+                result.Results[0].ExistingCreationTime);
+            Assert.AreEqual(secondCreationTime,
+                result.Results[1].ExistingCreationTime);
+        }
+
+        private static void CheckCreationTimeSupport()
+        {
+            if (KVVersion != null && KVVersion < CreationTimeVersion)
+            {
+                Assert.Inconclusive(
+                    "This test requires server creation-time support");
+            }
+        }
+
+        private static DateTime GetRequiredCreationTime(
+            GetResult<RecordValue> result)
+        {
+            Assert.IsNotNull(result.Row);
+            Assert.IsNotNull(result.CreationTime);
+            return result.CreationTime.Value;
+        }
+
+        private static MapValue CreateRow(int id, string name = null) =>
+            new MapValue
+            {
+                ["sid"] = ShardId,
+                ["id"] = id,
+                ["name"] = name ?? $"name-{id}"
+            };
+
+        private static MapValue CreateKey(int id) => new MapValue
+        {
+            ["sid"] = ShardId,
+            ["id"] = id
+        };
+
+        private static Task<GetResult<RecordValue>> GetRowAsync(int id) =>
+            client.GetAsync(Table.Name, CreateKey(id), new GetOptions
+            {
+                Consistency = Consistency.Absolute,
+                Timeout = TimeSpan.FromSeconds(20)
+            });
+    }
+}


### PR DESCRIPTION
## Summary

Implements KVSTORE-3618 by exposing the server-generated creation time returned by Oracle NoSQL Database.

- Adds `CreationTime` to `GetResult`.
- Adds `ExistingCreationTime` to Put, Delete, and WriteMany operation results.
- Deserializes the NSON `ct` field from Get row metadata and write `return_info` responses.
- Preserves compatibility with older servers: missing or zero creation times are exposed as `null`.
- Leaves the legacy binary protocol behavior unchanged, consistent with the Java SDK.

## Test Coverage

Added protocol and on-prem integration coverage for:

- Populated, missing, and zero creation-time values.
- Get, Put, Delete, and WriteMany responses.
- Conditional writes and existing-row return information.
- Immutable result behavior.

## Validation

- Release build completed successfully for net8.0, net9.0, and net10.0.
- Creation-time test suite: 7 tests passed on each target framework.
- Affected Get/Put/Delete/WriteMany/metadata regression suite: 2,097 tests passed.
- Stats unit tests: 61 tests passed.
- net10.0 smoke test and StatsLoadCheck `basicFlow` passed against the local KVStore server.