### PR TITLE
CSHARP SDK: Add query protocol V6 and UNION support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 **Added**
 * Latest OCI region codes
+* Added on-premises query protocol V6 support, including UNION ALL query
+  plans and V6 iterators.
 
 ## [5.2.3]
 

--- a/Oracle.NoSQL.SDK/src/BinaryProtocol/RequestSerializer.Query.cs
+++ b/Oracle.NoSQL.SDK/src/BinaryProtocol/RequestSerializer.Query.cs
@@ -143,7 +143,8 @@ namespace Oracle.NoSQL.SDK.BinaryProtocol
             if (request.PreparedStatement != null)
             {
                 WriteByteArrayWithUnpackedLength(stream,
-                    request.PreparedStatement.ProxyStatement);
+                    request.PreparedStatement.GetProxyStatement(
+                        request.UnionBranch));
                 var variables = request.PreparedStatement.variables;
                 if (variables != null)
                 {

--- a/Oracle.NoSQL.SDK/src/NoSQLClient.Internal.cs
+++ b/Oracle.NoSQL.SDK/src/NoSQLClient.Internal.cs
@@ -22,6 +22,8 @@ namespace Oracle.NoSQL.SDK
         private Http.Client client;
         private readonly object lockObj = new object();
         private volatile TopologyInfo queryTopology;
+        private readonly Dictionary<string, TopologyInfo> storeTopologies =
+            new Dictionary<string, TopologyInfo>();
         private readonly object disposeLock = new object();
         private bool disposed;
 
@@ -34,6 +36,30 @@ namespace Oracle.NoSQL.SDK
         internal StatsControlImpl StatsControl { get; private set; }
 
         internal TopologyInfo QueryTopology => queryTopology;
+
+        internal TopologyInfo GetQueryTopology(string storeName)
+        {
+            if (storeName == null)
+            {
+                return QueryTopology;
+            }
+            lock (lockObj)
+            {
+                return storeTopologies.TryGetValue(storeName, out var topology)
+                    ? topology : null;
+            }
+        }
+
+        internal IReadOnlyList<TopologyInfo> StoreTopologies
+        {
+            get
+            {
+                lock (lockObj)
+                {
+                    return new List<TopologyInfo>(storeTopologies.Values);
+                }
+            }
+        }
 
         internal int ServerSerialVersion => client.ServerSerialVersion;
 
@@ -55,6 +81,16 @@ namespace Oracle.NoSQL.SDK
         {
             lock (lockObj)
             {
+                if (topologyInfo.StoreName != null)
+                {
+                    if (!storeTopologies.TryGetValue(topologyInfo.StoreName,
+                            out var current) ||
+                        current.SequenceNumber < topologyInfo.SequenceNumber)
+                    {
+                        storeTopologies[topologyInfo.StoreName] = topologyInfo;
+                    }
+                    return;
+                }
                 if (queryTopology == null || queryTopology.SequenceNumber <
                     topologyInfo.SequenceNumber)
                 {

--- a/Oracle.NoSQL.SDK/src/NsonProtocol/Protocol.Reader.cs
+++ b/Oracle.NoSQL.SDK/src/NsonProtocol/Protocol.Reader.cs
@@ -209,6 +209,47 @@ namespace Oracle.NoSQL.SDK.NsonProtocol
             return result;
         }
 
+        internal static TopologyInfo ReadStoreTopologyInfo(NsonReader reader)
+        {
+            string storeName = null;
+            var sequenceNumber = -1;
+            int[] shardIds = null;
+            ReadMap(reader, fieldName =>
+            {
+                switch (fieldName)
+                {
+                    case FieldNames.StoreId:
+                        storeName = reader.ReadString();
+                        return true;
+                    case FieldNames.ProxyTopoSeqNum:
+                        sequenceNumber = reader.ReadInt32();
+                        return true;
+                    case FieldNames.ShardIds:
+                        shardIds = ReadArray(reader, reader.ReadInt32);
+                        return true;
+                    default:
+                        return false;
+                }
+            });
+            if (storeName == null)
+            {
+                throw new BadProtocolException(
+                    "Missing store id for store topology information");
+            }
+            if (sequenceNumber < 0)
+            {
+                throw new BadProtocolException(
+                    "Received invalid topology sequence number: " +
+                    sequenceNumber);
+            }
+            if (shardIds == null)
+            {
+                throw new BadProtocolException(
+                    "Missing shard ids for store topology information");
+            }
+            return new TopologyInfo(sequenceNumber, shardIds, storeName);
+        }
+
         internal static ConsumedCapacity DeserializeConsumedCapacity(
             NsonReader reader)
         {
@@ -266,6 +307,17 @@ namespace Oracle.NoSQL.SDK.NsonProtocol
                         // request.
                         request.Client.SetQueryTopology(
                             ReadTopologyInfo(reader));
+                        return true;
+                    case FieldNames.StoreTopologyInfo:
+                        var storeTopologies = ReadArray(reader,
+                            () => ReadStoreTopologyInfo(reader));
+                        if (storeTopologies != null)
+                        {
+                            foreach (var topology in storeTopologies)
+                            {
+                                request.Client.SetQueryTopology(topology);
+                            }
+                        }
                         return true;
                     default:
                         return processField(fieldName);

--- a/Oracle.NoSQL.SDK/src/NsonProtocol/Protocol.Writer.cs
+++ b/Oracle.NoSQL.SDK/src/NsonProtocol/Protocol.Writer.cs
@@ -44,7 +44,7 @@ namespace Oracle.NoSQL.SDK.NsonProtocol
                 request.RequestTimeoutMillis);
             writer.WriteInt32(FieldNames.TopoSeqNum,
                 request.QueryTopologySequenceNumber);
-            var storeTopologies = request.Client.StoreTopologies;
+            var storeTopologies = request.StoreTopologies;
             if (storeTopologies.Count != 0)
             {
                 writer.StartArray(FieldNames.StoreTopologySequenceNumbers);

--- a/Oracle.NoSQL.SDK/src/NsonProtocol/Protocol.Writer.cs
+++ b/Oracle.NoSQL.SDK/src/NsonProtocol/Protocol.Writer.cs
@@ -44,6 +44,20 @@ namespace Oracle.NoSQL.SDK.NsonProtocol
                 request.RequestTimeoutMillis);
             writer.WriteInt32(FieldNames.TopoSeqNum,
                 request.QueryTopologySequenceNumber);
+            var storeTopologies = request.Client.StoreTopologies;
+            if (storeTopologies.Count != 0)
+            {
+                writer.StartArray(FieldNames.StoreTopologySequenceNumbers);
+                foreach (var topology in storeTopologies)
+                {
+                    writer.StartMap();
+                    writer.WriteString(FieldNames.StoreId, topology.StoreName);
+                    writer.WriteInt32(FieldNames.TopoSeqNum,
+                        topology.SequenceNumber);
+                    writer.EndMap();
+                }
+                writer.EndArray();
+            }
             writer.EndMap();
         }
 

--- a/Oracle.NoSQL.SDK/src/NsonProtocol/Protocol.cs
+++ b/Oracle.NoSQL.SDK/src/NsonProtocol/Protocol.cs
@@ -60,6 +60,7 @@ namespace Oracle.NoSQL.SDK.NsonProtocol
             internal const string Query = "q";
             internal const string QueryName = "qn";
             internal const string QueryVersion = "qv";
+            internal const string QueryBranches = "qb";
             internal const string Range = "rg";
             internal const string RangePath = "rp";
             internal const string ReadThrottleCount = "rt";
@@ -164,6 +165,8 @@ namespace Oracle.NoSQL.SDK.NsonProtocol
             internal const string VirtualScans = "vssa";
             internal const string VirtualScanSID = "vssid";
             internal const string VirtualScanPID = "vspid";
+            internal const string VirtualScanNumTables = "vsnt";
+            internal const string VirtualScanCurrentIndexRange = "vscir";
             internal const string VirtualScanPrimKey = "vspk";
             internal const string VirtualScanSecKey = "vssk";
             internal const string VirtualScanMoveAfter = "vsma";

--- a/Oracle.NoSQL.SDK/src/NsonProtocol/Protocol.cs
+++ b/Oracle.NoSQL.SDK/src/NsonProtocol/Protocol.cs
@@ -61,6 +61,7 @@ namespace Oracle.NoSQL.SDK.NsonProtocol
             internal const string QueryName = "qn";
             internal const string QueryVersion = "qv";
             internal const string QueryBranches = "qb";
+            internal const string QueryBranchStores = "qbs";
             internal const string Range = "rg";
             internal const string RangePath = "rp";
             internal const string ReadThrottleCount = "rt";
@@ -79,6 +80,8 @@ namespace Oracle.NoSQL.SDK.NsonProtocol
             internal const string TableUsagePeriod = "pd";
             internal const string Timeout = "t";
             internal const string TopoSeqNum = "ts";
+            internal const string StoreId = "sid";
+            internal const string StoreTopologySequenceNumbers = "sts";
             internal const string TraceLevel = "tl";
             internal const string TraceToLogFiles = "tf";
             internal const string TTL = "tt";
@@ -153,6 +156,7 @@ namespace Oracle.NoSQL.SDK.NsonProtocol
             internal const string SortPhase1Results = "p1";
             internal const string TableAccessInfo = "ai";
             internal const string TopologyInfo = "tp";
+            internal const string StoreTopologyInfo = "stp";
 
             // replica stats response fields
             internal const string NextStartTime = "ni";

--- a/Oracle.NoSQL.SDK/src/NsonProtocol/RequestSerializer.Query.cs
+++ b/Oracle.NoSQL.SDK/src/NsonProtocol/RequestSerializer.Query.cs
@@ -39,10 +39,10 @@ namespace Oracle.NoSQL.SDK.NsonProtocol
         }
 
         private static void DeserializeDriverPlanInfo(MemoryStream stream,
-            PreparedStatement statement)
+            PreparedStatement statement, short queryVersion)
         {
             statement.DriverQueryPlan = PlanSerializer.DeserializeStep(
-                stream);
+                stream, queryVersion);
             
             if (statement.DriverQueryPlan == null)
             {
@@ -79,9 +79,33 @@ namespace Oracle.NoSQL.SDK.NsonProtocol
         }
 
         // topology info is not always sent
+        private static PreparedStatement.QueryBranch DeserializeQueryBranch(
+            NsonReader reader)
+        {
+            var branch = new PreparedStatement.QueryBranch();
+            ReadMap(reader, field =>
+            {
+                switch (field)
+                {
+                    case FieldNames.PreparedQuery:
+                        branch.ProxyStatement = reader.ReadByteArray();
+                        return true;
+                    case FieldNames.Namespace:
+                        branch.Namespace = reader.ReadString();
+                        return true;
+                    case FieldNames.TableName:
+                        branch.TableName = reader.ReadString();
+                        return true;
+                    default:
+                        return false;
+                }
+            });
+            return branch;
+        }
+
         private static bool ProcessPreparedStatementField(NsonReader reader,
             string field, ref PreparedStatement statement,
-            ref MutableTopologyInfo topologyInfo)
+            ref MutableTopologyInfo topologyInfo, short queryVersion)
         {
             switch (field)
             {
@@ -93,7 +117,20 @@ namespace Oracle.NoSQL.SDK.NsonProtocol
                     statement ??= new PreparedStatement();
                     var stream = GetMemoryStreamWithVisibleBuffer(
                         reader.ReadByteArray());
-                    DeserializeDriverPlanInfo(stream, statement);
+                    DeserializeDriverPlanInfo(stream, statement, queryVersion);
+                    return true;
+                case FieldNames.QueryBranches:
+                    statement ??= new PreparedStatement();
+                    var branches = ReadArray(reader, DeserializeQueryBranch);
+                    if (branches == null || branches.Length == 0)
+                    {
+                        throw new BadProtocolException(
+                            "Query: received empty query branches");
+                    }
+                    foreach (var branch in branches)
+                    {
+                        statement.AddQueryBranch(branch);
+                    }
                     return true;
                 case FieldNames.TableName:
                     statement ??= new PreparedStatement();
@@ -190,7 +227,7 @@ namespace Oracle.NoSQL.SDK.NsonProtocol
         }
 
         private static void SerializeVirtualScan(NsonWriter writer,
-            VirtualScan vs)
+            VirtualScan vs, short queryVersion)
         {
             writer.StartMap(FieldNames.VirtualScan);
             writer.WriteInt32(FieldNames.VirtualScanSID, vs.ShardId);
@@ -198,30 +235,48 @@ namespace Oracle.NoSQL.SDK.NsonProtocol
 
             if (!vs.IsInfoSent)
             {
-                writer.WriteByteArray(FieldNames.VirtualScanPrimKey,
-                    vs.PrimaryKey);
-                writer.WriteByteArray(FieldNames.VirtualScanSecKey,
-                    vs.SecondaryKey);
-                writer.WriteBoolean(FieldNames.VirtualScanMoveAfter,
-                    vs.MoveAfterResumeKey);
-
-                writer.WriteByteArray(FieldNames.VirtualScanJoinDescResumeKey,
-                    vs.JoinDescendantResumeKey);
-
-                if (vs.JoinPathTableIds != null)
+                var tableInfos = vs.TableResumeInfos;
+                if (tableInfos == null || tableInfos.Length == 0)
                 {
-                    writer.WriteFieldName(
-                        FieldNames.VirtualScanJoinPathTables);
-                    WriteArray(writer, vs.JoinPathTableIds,
-                        writer.WriteInt32);
+                    throw new BadProtocolException(
+                        "Query: virtual scan has no table resume information");
                 }
-                
-                writer.WriteByteArray(FieldNames.VirtualScanJoinPathKey,
-                    vs.JoinPathPrimaryKey);
-                writer.WriteByteArray(FieldNames.VirtualScanJoinPathSecKey,
-                    vs.JoinPathSecondaryKey);
-                writer.WriteBoolean(FieldNames.VirtualScanJoinPathMatched,
-                    vs.JoinPathMatched);
+
+                var count = queryVersion >= QueryRequestBase.QueryV5 ?
+                    tableInfos.Length : 1;
+                if (queryVersion >= QueryRequestBase.QueryV5)
+                {
+                    writer.WriteInt32(FieldNames.VirtualScanNumTables, count);
+                }
+
+                for (var i = 0; i < count; i++)
+                {
+                    var info = tableInfos[i];
+                    writer.WriteInt32(FieldNames.VirtualScanCurrentIndexRange,
+                        info.CurrentIndexRange);
+                    writer.WriteByteArray(FieldNames.VirtualScanPrimKey,
+                        info.PrimaryKey);
+                    writer.WriteByteArray(FieldNames.VirtualScanSecKey,
+                        info.SecondaryKey);
+                    writer.WriteBoolean(FieldNames.VirtualScanMoveAfter,
+                        info.MoveAfterResumeKey);
+                    writer.WriteByteArray(
+                        FieldNames.VirtualScanJoinDescResumeKey,
+                        info.JoinDescendantResumeKey);
+                    if (info.JoinPathTableIds != null)
+                    {
+                        writer.WriteFieldName(
+                            FieldNames.VirtualScanJoinPathTables);
+                        WriteArray(writer, info.JoinPathTableIds,
+                            writer.WriteInt32);
+                    }
+                    writer.WriteByteArray(FieldNames.VirtualScanJoinPathKey,
+                        info.JoinPathPrimaryKey);
+                    writer.WriteByteArray(FieldNames.VirtualScanJoinPathSecKey,
+                        info.JoinPathSecondaryKey);
+                    writer.WriteBoolean(FieldNames.VirtualScanJoinPathMatched,
+                        info.JoinPathMatched);
+                }
             }
 
             writer.EndMap();
@@ -230,6 +285,10 @@ namespace Oracle.NoSQL.SDK.NsonProtocol
         private static VirtualScan DeserializeVirtualScan(NsonReader reader)
         {
             var result = new VirtualScan();
+            var tableInfos = new List<VirtualScan.TableResumeInfo>();
+            var tableInfo = new VirtualScan.TableResumeInfo();
+            var tableCount = 1;
+            var hasTableCount = false;
 
             ReadMap(reader, field =>
             {
@@ -241,36 +300,64 @@ namespace Oracle.NoSQL.SDK.NsonProtocol
                     case FieldNames.VirtualScanPID:
                         result.PartitionId = reader.ReadInt32();
                         return true;
+                    case FieldNames.VirtualScanNumTables:
+                        tableCount = reader.ReadInt32();
+                        hasTableCount = true;
+                        if (tableCount <= 0)
+                        {
+                            throw new BadProtocolException(
+                                "Query: invalid virtual scan table count " +
+                                tableCount);
+                        }
+                        return true;
+                    case FieldNames.VirtualScanCurrentIndexRange:
+                        tableInfo.CurrentIndexRange = reader.ReadInt32();
+                        return true;
                     case FieldNames.VirtualScanPrimKey:
-                        result.PrimaryKey = reader.ReadByteArray();
+                        tableInfo.PrimaryKey = reader.ReadByteArray();
                         return true;
                     case FieldNames.VirtualScanSecKey:
-                        result.SecondaryKey = reader.ReadByteArray();
+                        tableInfo.SecondaryKey = reader.ReadByteArray();
                         return true;
                     case FieldNames.VirtualScanMoveAfter:
-                        result.MoveAfterResumeKey = reader.ReadBoolean();
+                        tableInfo.MoveAfterResumeKey = reader.ReadBoolean();
                         return true;
                     case FieldNames.VirtualScanJoinDescResumeKey:
-                        result.JoinDescendantResumeKey =
+                        tableInfo.JoinDescendantResumeKey =
                             reader.ReadByteArray();
                         return true;
                     case FieldNames.VirtualScanJoinPathTables:
-                        result.JoinPathTableIds =
+                        tableInfo.JoinPathTableIds =
                             ReadArray(reader, reader.ReadInt32);
                         return true;
                     case FieldNames.VirtualScanJoinPathKey:
-                        result.JoinPathPrimaryKey = reader.ReadByteArray();
+                        tableInfo.JoinPathPrimaryKey = reader.ReadByteArray();
                         return true;
                     case FieldNames.VirtualScanJoinPathSecKey:
-                        result.JoinPathSecondaryKey = reader.ReadByteArray();
+                        tableInfo.JoinPathSecondaryKey = reader.ReadByteArray();
                         return true;
                     case FieldNames.VirtualScanJoinPathMatched:
-                        result.JoinPathMatched = reader.ReadBoolean();
+                        tableInfo.JoinPathMatched = reader.ReadBoolean();
+                        tableInfos.Add(tableInfo);
+                        tableInfo = new VirtualScan.TableResumeInfo();
                         return true;
                     default:
                         return false;
                 }
             });
+
+            if ((hasTableCount || tableInfos.Count != 0) &&
+                tableInfos.Count != tableCount)
+            {
+                throw new BadProtocolException(
+                    "Query: received mismatched virtual scan table resume " +
+                    $"information, expected {tableCount}, got {tableInfos.Count}");
+            }
+
+            if (tableInfos.Count != 0)
+            {
+                result.TableResumeInfos = tableInfos.ToArray();
+            }
 
             return result;
         }
@@ -331,7 +418,8 @@ namespace Oracle.NoSQL.SDK.NsonProtocol
 
             DeserializeResponse(reader,
                 field => ProcessPreparedStatementField(reader, field,
-                    ref statement, ref mti), request, statement);
+                    ref statement, ref mti, request.QueryVersion), request,
+                statement);
             ValidatePreparedStatement(statement);
             
             // Only for query <= V3.
@@ -393,7 +481,8 @@ namespace Oracle.NoSQL.SDK.NsonProtocol
                 writer.WriteBoolean(FieldNames.IsSimpleQuery,
                     request.PreparedStatement.IsSimpleQuery);
                 writer.WriteByteArray(FieldNames.PreparedQuery,
-                    request.PreparedStatement.ProxyStatement);
+                    request.PreparedStatement.GetProxyStatement(
+                        request.UnionBranch));
 
                 var variables = request.PreparedStatement.variables;
                 if (variables != null)
@@ -443,7 +532,8 @@ namespace Oracle.NoSQL.SDK.NsonProtocol
                     request.Options?.QueryLabel);
                 if (request.VirtualScan != null)
                 {
-                    SerializeVirtualScan(writer, request.VirtualScan);
+                    SerializeVirtualScan(writer, request.VirtualScan,
+                        request.QueryVersion);
                 }
             }
 
@@ -492,7 +582,8 @@ namespace Oracle.NoSQL.SDK.NsonProtocol
                         return true;
                     default:
                         return ProcessPreparedStatementField(reader, field,
-                            ref preparedStatement, ref mti);
+                            ref preparedStatement, ref mti,
+                            request.QueryVersion);
                 }
             }, request, result);
 

--- a/Oracle.NoSQL.SDK/src/NsonProtocol/RequestSerializer.Query.cs
+++ b/Oracle.NoSQL.SDK/src/NsonProtocol/RequestSerializer.Query.cs
@@ -105,7 +105,8 @@ namespace Oracle.NoSQL.SDK.NsonProtocol
 
         private static bool ProcessPreparedStatementField(NsonReader reader,
             string field, ref PreparedStatement statement,
-            ref MutableTopologyInfo topologyInfo, short queryVersion)
+            ref MutableTopologyInfo topologyInfo,
+            ref string[] branchStoreNames, short queryVersion)
         {
             switch (field)
             {
@@ -130,6 +131,20 @@ namespace Oracle.NoSQL.SDK.NsonProtocol
                     foreach (var branch in branches)
                     {
                         statement.AddQueryBranch(branch);
+                    }
+                    return true;
+                case FieldNames.QueryBranchStores:
+                    branchStoreNames = ReadArray(reader, reader.ReadString);
+                    if (branchStoreNames != null)
+                    {
+                        foreach (var storeName in branchStoreNames)
+                        {
+                            if (string.IsNullOrWhiteSpace(storeName))
+                            {
+                                throw new BadProtocolException(
+                                    "Query: received empty branch store id");
+                            }
+                        }
                     }
                     return true;
                 case FieldNames.TableName:
@@ -165,6 +180,12 @@ namespace Oracle.NoSQL.SDK.NsonProtocol
                 default:
                     return false;
             }
+        }
+
+        private static void SetQueryBranchStores(PreparedStatement statement,
+            string[] branchStoreNames)
+        {
+            statement?.SetQueryBranchStores(branchStoreNames);
         }
 
         // Validates the server portion of the prepared statement from the
@@ -415,11 +436,14 @@ namespace Oracle.NoSQL.SDK.NsonProtocol
                 SQLText = request.Statement
             };
             MutableTopologyInfo mti = null;
+            string[] branchStoreNames = null;
 
             DeserializeResponse(reader,
                 field => ProcessPreparedStatementField(reader, field,
-                    ref statement, ref mti, request.QueryVersion), request,
+                    ref statement, ref mti, ref branchStoreNames,
+                    request.QueryVersion), request,
                 statement);
+            SetQueryBranchStores(statement, branchStoreNames);
             ValidatePreparedStatement(statement);
             
             // Only for query <= V3.
@@ -483,6 +507,8 @@ namespace Oracle.NoSQL.SDK.NsonProtocol
                 writer.WriteByteArray(FieldNames.PreparedQuery,
                     request.PreparedStatement.GetProxyStatement(
                         request.UnionBranch));
+                OptionallyWriteString(writer, FieldNames.StoreId,
+                    request.PreparedStatement.GetStoreName(request.UnionBranch));
 
                 var variables = request.PreparedStatement.variables;
                 if (variables != null)
@@ -548,6 +574,7 @@ namespace Oracle.NoSQL.SDK.NsonProtocol
             var result = new QueryResult<TRow>();
             PreparedStatement preparedStatement = null;
             MutableTopologyInfo mti = null;
+            string[] branchStoreNames = null;
 
             DeserializeResponse(reader, field =>
             {
@@ -583,9 +610,16 @@ namespace Oracle.NoSQL.SDK.NsonProtocol
                     default:
                         return ProcessPreparedStatementField(reader, field,
                             ref preparedStatement, ref mti,
+                            ref branchStoreNames,
                             request.QueryVersion);
                 }
             }, request, result);
+
+            if (branchStoreNames != null)
+            {
+                SetQueryBranchStores(preparedStatement ??
+                    request.PreparedStatement, branchStoreNames);
+            }
 
             /*
              * If the QueryRequest was not initially prepared, the prepared

--- a/Oracle.NoSQL.SDK/src/ProtocolHandler.cs
+++ b/Oracle.NoSQL.SDK/src/ProtocolHandler.cs
@@ -91,10 +91,9 @@ namespace Oracle.NoSQL.SDK
                     return true;
                 }
 
-                // Allow fallback from V4 to V3.
-                if (queryVersion == QueryRequestBase.QueryV4)
+                if (queryVersion > QueryRequestBase.QueryV3)
                 {
-                    queryVersion = QueryRequestBase.QueryV3;
+                    --queryVersion;
                     return true;
                 }
 

--- a/Oracle.NoSQL.SDK/src/Query/AggregateFuncIterators.cs
+++ b/Oracle.NoSQL.SDK/src/Query/AggregateFuncIterators.cs
@@ -102,8 +102,8 @@ namespace Oracle.NoSQL.SDK.Query {
             this.step = step;
             Aggregator = step.IsDistinct
                 ? (ValueAggregator)new CollectDistinctAggregator(
-                    runtime.IsForTest)
-                : new CollectAggregator(runtime.IsForTest);
+                    runtime.IsForTest, false)
+                : new CollectAggregator(runtime.IsForTest, false);
         }
 
         internal override PlanStep Step => step;

--- a/Oracle.NoSQL.SDK/src/Query/AggregateFuncIterators.cs
+++ b/Oracle.NoSQL.SDK/src/Query/AggregateFuncIterators.cs
@@ -102,8 +102,8 @@ namespace Oracle.NoSQL.SDK.Query {
             this.step = step;
             Aggregator = step.IsDistinct
                 ? (ValueAggregator)new CollectDistinctAggregator(
-                    runtime.IsForTest, false)
-                : new CollectAggregator(runtime.IsForTest, false);
+                    runtime.IsForTest, true)
+                : new CollectAggregator(runtime.IsForTest, true);
         }
 
         internal override PlanStep Step => step;

--- a/Oracle.NoSQL.SDK/src/Query/BinaryProtocol/PlanSerializer.cs
+++ b/Oracle.NoSQL.SDK/src/Query/BinaryProtocol/PlanSerializer.cs
@@ -32,7 +32,8 @@ namespace Oracle.NoSQL.SDK.Query.BinaryProtocol
             FnMinMax = 41,
             Group = 65,
             Sort2 = 66,
-            FnCollect = 78
+            FnCollect = 78,
+            Union = 90
         }
 
         private static void DeserializeBase(MemoryStream stream,
@@ -100,11 +101,11 @@ namespace Oracle.NoSQL.SDK.Query.BinaryProtocol
         }
 
         private static SortStep DeserializeSortStep(MemoryStream stream,
-            StepType stepType)
+            StepType stepType, short queryVersion)
         {
             var step = new SortStep();
             DeserializeBase(stream, step);
-            step.InputStep = DeserializeStep(stream);
+            step.InputStep = DeserializeStep(stream, queryVersion);
             step.SortSpecs = DeserializeSortSpecs(stream, step);
             step.CountMemory = stepType != StepType.Sort2 ||
                 ReadBoolean(stream);
@@ -112,7 +113,8 @@ namespace Oracle.NoSQL.SDK.Query.BinaryProtocol
             return step;
         }
 
-        private static SFWStep DeserializeSFWStep(MemoryStream stream)
+        private static SFWStep DeserializeSFWStep(MemoryStream stream,
+            short queryVersion)
         {
             var step = new SFWStep();
             DeserializeBase(stream, step);
@@ -120,10 +122,10 @@ namespace Oracle.NoSQL.SDK.Query.BinaryProtocol
             step.GroupColumnCount = ReadUnpackedInt32(stream);
             step.FromVarName = ReadString(stream);
             step.IsSelectStar = ReadBoolean(stream);
-            step.ColumnSteps = DeserializeMultipleSteps(stream);
-            step.FromStep = DeserializeStep(stream);
-            step.OffsetStep = DeserializeStep(stream);
-            step.LimitStep = DeserializeStep(stream);
+            step.ColumnSteps = DeserializeMultipleSteps(stream, queryVersion);
+            step.FromStep = DeserializeStep(stream, queryVersion);
+            step.OffsetStep = DeserializeStep(stream, queryVersion);
+            step.LimitStep = DeserializeStep(stream, queryVersion);
             ValidateSFWStep(step);
             return step;
         }
@@ -170,39 +172,41 @@ namespace Oracle.NoSQL.SDK.Query.BinaryProtocol
             return step;
         }
 
-        private static FieldStep DeserializeFieldStep(MemoryStream stream)
+        private static FieldStep DeserializeFieldStep(MemoryStream stream,
+            short queryVersion)
         {
             var step = new FieldStep();
             DeserializeBase(stream, step);
-            step.InputStep = DeserializeStep(stream);
+            step.InputStep = DeserializeStep(stream, queryVersion);
             step.FieldName = ReadString(stream);
             ValidateFieldStep(step);
             return step;
         }
 
         private static ArithmeticOpStep DeserializeArithmeticStep(
-            MemoryStream stream)
+            MemoryStream stream, short queryVersion)
         {
             var step = new ArithmeticOpStep();
             DeserializeBase(stream, step);
             step.Opcode = (ArithmeticOpcode)ReadUnpackedInt16(stream);
-            step.ArgSteps = DeserializeMultipleSteps(stream);
+            step.ArgSteps = DeserializeMultipleSteps(stream, queryVersion);
             step.OpSequence = ReadString(stream);
             ValidateArithmeticOpStep(step);
             return step;
         }
 
-        private static FuncSumStep DeserializeFuncSumStep(MemoryStream stream)
+        private static FuncSumStep DeserializeFuncSumStep(MemoryStream stream,
+            short queryVersion)
         {
             var step = new FuncSumStep();
             DeserializeBase(stream, step);
-            step.InputStep = DeserializeStep(stream);
+            step.InputStep = DeserializeStep(stream, queryVersion);
             ValidateFuncSumStep(step);
             return step;
         }
 
         private static FuncMinMaxStep DeserializeFuncMinMaxStep(
-            MemoryStream stream)
+            MemoryStream stream, short queryVersion)
         {
             var step = new FuncMinMaxStep();
             DeserializeBase(stream, step);
@@ -215,36 +219,38 @@ namespace Oracle.NoSQL.SDK.Query.BinaryProtocol
                     $"min/max operation: {code}");
             }
 
-            step.InputStep = DeserializeStep(stream);
+            step.InputStep = DeserializeStep(stream, queryVersion);
             ValidateFuncMinMaxStep(step);
             return step;
         }
 
-        private static FuncSizeStep DeserializeFuncSizeStep(MemoryStream stream)
+        private static FuncSizeStep DeserializeFuncSizeStep(MemoryStream stream,
+            short queryVersion)
         {
             var step = new FuncSizeStep();
             DeserializeBase(stream, step);
-            step.InputStep = DeserializeStep(stream);
+            step.InputStep = DeserializeStep(stream, queryVersion);
             ValidateFuncSizeStep(step);
             return step;
         }
 
         private static FuncCollectStep DeserializeFuncCollectStep(
-            MemoryStream stream)
+            MemoryStream stream, short queryVersion)
         {
             var step = new FuncCollectStep();
             DeserializeBase(stream, step);
             step.IsDistinct = ReadBoolean(stream);
-            step.InputStep = DeserializeStep(stream);
+            step.InputStep = DeserializeStep(stream, queryVersion);
             ValidateFuncCollectStep(step);
             return step;
         }
 
-        private static GroupStep DeserializeGroupStep(MemoryStream stream)
+        private static GroupStep DeserializeGroupStep(MemoryStream stream,
+            short queryVersion)
         {
             var step = new GroupStep();
             DeserializeBase(stream, step);
-            step.InputStep = DeserializeStep(stream);
+            step.InputStep = DeserializeStep(stream, queryVersion);
             step.GroupingColumnCount = ReadUnpackedInt32(stream);
             CheckNotNegative(step.GroupingColumnCount,
                 "group by column count", step);
@@ -272,16 +278,31 @@ namespace Oracle.NoSQL.SDK.Query.BinaryProtocol
             step.IsDistinct = ReadBoolean(stream);
             step.RemoveResult = ReadBoolean(stream);
             step.CountMemory = ReadBoolean(stream);
+            step.IsRegrouping = queryVersion >= QueryRequestBase.QueryV6 &&
+                ReadBoolean(stream);
             ValidateGroupStep(step);
             return step;
         }
 
-        private static PlanStep[] DeserializeMultipleSteps(MemoryStream stream)
+        private static UnionStep DeserializeUnionStep(MemoryStream stream,
+            short queryVersion)
         {
-            return ReadArray(stream, DeserializeStep);
+            var step = new UnionStep();
+            DeserializeBase(stream, step);
+            step.BranchSteps = DeserializeMultipleSteps(stream, queryVersion);
+            step.SortSpecs = DeserializeSortSpecs(stream, step);
+            ValidateUnionStep(step);
+            return step;
         }
 
-        internal static PlanStep DeserializeStep(MemoryStream stream)
+        private static PlanStep[] DeserializeMultipleSteps(MemoryStream stream,
+            short queryVersion)
+        {
+            return ReadArray(stream, s => DeserializeStep(s, queryVersion));
+        }
+
+        internal static PlanStep DeserializeStep(MemoryStream stream,
+            short queryVersion = QueryRequestBase.QueryV3)
         {
             var stepType = (StepType)ReadByte(stream);
             switch (stepType)
@@ -289,9 +310,9 @@ namespace Oracle.NoSQL.SDK.Query.BinaryProtocol
                 case StepType.None:
                     return null;
                 case StepType.Sort: case StepType.Sort2:
-                    return DeserializeSortStep(stream, stepType);
+                    return DeserializeSortStep(stream, stepType, queryVersion);
                 case StepType.SFW:
-                    return DeserializeSFWStep(stream);
+                    return DeserializeSFWStep(stream, queryVersion);
                 case StepType.Recv:
                     return DeserializeReceiveStep(stream);
                 case StepType.Const:
@@ -301,19 +322,21 @@ namespace Oracle.NoSQL.SDK.Query.BinaryProtocol
                 case StepType.ExternalVarRef:
                     return DeserializeExtVarRefStep(stream);
                 case StepType.FieldStep:
-                    return DeserializeFieldStep(stream);
+                    return DeserializeFieldStep(stream, queryVersion);
                 case StepType.ArithOp:
-                    return DeserializeArithmeticStep(stream);
+                    return DeserializeArithmeticStep(stream, queryVersion);
                 case StepType.FnSum:
-                    return DeserializeFuncSumStep(stream);
+                    return DeserializeFuncSumStep(stream, queryVersion);
                 case StepType.FnMinMax:
-                    return DeserializeFuncMinMaxStep(stream);
+                    return DeserializeFuncMinMaxStep(stream, queryVersion);
                 case StepType.FnSize:
-                    return DeserializeFuncSizeStep(stream);
+                    return DeserializeFuncSizeStep(stream, queryVersion);
                 case StepType.FnCollect:
-                    return DeserializeFuncCollectStep(stream);
+                    return DeserializeFuncCollectStep(stream, queryVersion);
                 case StepType.Group:
-                    return DeserializeGroupStep(stream);
+                    return DeserializeGroupStep(stream, queryVersion);
+                case StepType.Union:
+                    return DeserializeUnionStep(stream, queryVersion);
                 default:
                     throw new BadProtocolException(
                         "Query plan: received invalid or unsupported step " +

--- a/Oracle.NoSQL.SDK/src/Query/BinaryProtocol/PlanSerializer.cs
+++ b/Oracle.NoSQL.SDK/src/Query/BinaryProtocol/PlanSerializer.cs
@@ -25,14 +25,20 @@ namespace Oracle.NoSQL.SDK.Query.BinaryProtocol
             Const = 0,
             VarRef = 1,
             ExternalVarRef = 2,
+            ArrayConstructor = 3,
+            ValueCompare = 5,
+            AndOr = 7,
             FieldStep = 11,
             ArithOp = 8,
             FnSize = 15,
+            Case = 19,
+            IsNull = 26,
             FnSum = 39,
             FnMinMax = 41,
             Group = 65,
             Sort2 = 66,
             FnCollect = 78,
+            SeqAggr = 48,
             Union = 90
         }
 
@@ -98,6 +104,19 @@ namespace Oracle.NoSQL.SDK.Query.BinaryProtocol
             }
 
             return (SQLFuncCode)val;
+        }
+
+        private static QueryFuncCode DeserializeQueryFuncCode(
+            MemoryStream stream, PlanStep parent)
+        {
+            var value = ReadUnpackedInt16(stream);
+            if (!Enum.IsDefined(typeof(QueryFuncCode), (int)value))
+            {
+                throw new BadProtocolException(
+                    $"Query plan: received invalid function code: {value} " +
+                    $"in {parent.Name} step");
+            }
+            return (QueryFuncCode)value;
         }
 
         private static SortStep DeserializeSortStep(MemoryStream stream,
@@ -295,6 +314,74 @@ namespace Oracle.NoSQL.SDK.Query.BinaryProtocol
             return step;
         }
 
+        private static ArrayConstructorStep DeserializeArrayConstructorStep(
+            MemoryStream stream, short queryVersion)
+        {
+            var step = new ArrayConstructorStep();
+            DeserializeBase(stream, step);
+            step.IsConditional = ReadBoolean(stream);
+            step.ArgSteps = DeserializeMultipleSteps(stream, queryVersion);
+            ValidateArrayConstructorStep(step);
+            return step;
+        }
+
+        private static ValueCompareStep DeserializeValueCompareStep(
+            MemoryStream stream, short queryVersion)
+        {
+            var step = new ValueCompareStep();
+            DeserializeBase(stream, step);
+            step.FuncCode = DeserializeQueryFuncCode(stream, step);
+            step.LeftStep = DeserializeStep(stream, queryVersion);
+            step.RightStep = DeserializeStep(stream, queryVersion);
+            ValidateValueCompareStep(step);
+            return step;
+        }
+
+        private static AndOrStep DeserializeAndOrStep(MemoryStream stream,
+            short queryVersion)
+        {
+            var step = new AndOrStep();
+            DeserializeBase(stream, step);
+            step.FuncCode = DeserializeQueryFuncCode(stream, step);
+            step.ArgSteps = DeserializeMultipleSteps(stream, queryVersion);
+            ValidateAndOrStep(step);
+            return step;
+        }
+
+        private static CaseStep DeserializeCaseStep(MemoryStream stream,
+            short queryVersion)
+        {
+            var step = new CaseStep();
+            DeserializeBase(stream, step);
+            step.ConditionSteps = DeserializeMultipleSteps(stream, queryVersion);
+            step.ThenSteps = DeserializeMultipleSteps(stream, queryVersion);
+            step.ElseStep = DeserializeStep(stream, queryVersion);
+            ValidateCaseStep(step);
+            return step;
+        }
+
+        private static IsNullStep DeserializeIsNullStep(MemoryStream stream,
+            short queryVersion)
+        {
+            var step = new IsNullStep();
+            DeserializeBase(stream, step);
+            step.FuncCode = DeserializeQueryFuncCode(stream, step);
+            step.InputStep = DeserializeStep(stream, queryVersion);
+            ValidateIsNullStep(step);
+            return step;
+        }
+
+        private static SeqAggregateStep DeserializeSeqAggregateStep(
+            MemoryStream stream, short queryVersion)
+        {
+            var step = new SeqAggregateStep();
+            DeserializeBase(stream, step);
+            step.FuncCode = DeserializeQueryFuncCode(stream, step);
+            step.InputStep = DeserializeStep(stream, queryVersion);
+            ValidateSeqAggregateStep(step);
+            return step;
+        }
+
         private static PlanStep[] DeserializeMultipleSteps(MemoryStream stream,
             short queryVersion)
         {
@@ -321,6 +408,12 @@ namespace Oracle.NoSQL.SDK.Query.BinaryProtocol
                     return DeserializeVarRefStep(stream);
                 case StepType.ExternalVarRef:
                     return DeserializeExtVarRefStep(stream);
+                case StepType.ArrayConstructor:
+                    return DeserializeArrayConstructorStep(stream, queryVersion);
+                case StepType.ValueCompare:
+                    return DeserializeValueCompareStep(stream, queryVersion);
+                case StepType.AndOr:
+                    return DeserializeAndOrStep(stream, queryVersion);
                 case StepType.FieldStep:
                     return DeserializeFieldStep(stream, queryVersion);
                 case StepType.ArithOp:
@@ -331,12 +424,18 @@ namespace Oracle.NoSQL.SDK.Query.BinaryProtocol
                     return DeserializeFuncMinMaxStep(stream, queryVersion);
                 case StepType.FnSize:
                     return DeserializeFuncSizeStep(stream, queryVersion);
+                case StepType.Case:
+                    return DeserializeCaseStep(stream, queryVersion);
+                case StepType.IsNull:
+                    return DeserializeIsNullStep(stream, queryVersion);
                 case StepType.FnCollect:
                     return DeserializeFuncCollectStep(stream, queryVersion);
                 case StepType.Group:
                     return DeserializeGroupStep(stream, queryVersion);
                 case StepType.Union:
                     return DeserializeUnionStep(stream, queryVersion);
+                case StepType.SeqAggr:
+                    return DeserializeSeqAggregateStep(stream, queryVersion);
                 default:
                     throw new BadProtocolException(
                         "Query plan: received invalid or unsupported step " +

--- a/Oracle.NoSQL.SDK/src/Query/BinaryProtocol/PlanSerializer.cs
+++ b/Oracle.NoSQL.SDK/src/Query/BinaryProtocol/PlanSerializer.cs
@@ -297,7 +297,9 @@ namespace Oracle.NoSQL.SDK.Query.BinaryProtocol
             step.IsDistinct = ReadBoolean(stream);
             step.RemoveResult = ReadBoolean(stream);
             step.CountMemory = ReadBoolean(stream);
-            step.IsRegrouping = queryVersion >= QueryRequestBase.QueryV6 &&
+            // Before V6 the regrouping flag was not sent. Preserve the
+            // existing C# behavior for those proxy partial array results.
+            step.IsRegrouping = queryVersion < QueryRequestBase.QueryV6 ||
                 ReadBoolean(stream);
             ValidateGroupStep(step);
             return step;

--- a/Oracle.NoSQL.SDK/src/Query/GroupIterator.cs
+++ b/Oracle.NoSQL.SDK/src/Query/GroupIterator.cs
@@ -123,11 +123,13 @@ namespace Oracle.NoSQL.SDK.Query {
                         break;
                     case SQLFuncCode.ArrayCollect:
                         aggregateTuple[i] =
-                            new CollectAggregator(runtime.IsForTest);
+                            new CollectAggregator(runtime.IsForTest,
+                                step.IsRegrouping);
                         break;
                     case SQLFuncCode.ArrayCollectDistinct:
                         aggregateTuple[i] =
-                            new CollectDistinctAggregator(runtime.IsForTest);
+                            new CollectDistinctAggregator(runtime.IsForTest,
+                                step.IsRegrouping);
                         break;
                     default:
                         // this is already checked in DeserializeSQLFuncCode

--- a/Oracle.NoSQL.SDK/src/Query/PlanFormatter.cs
+++ b/Oracle.NoSQL.SDK/src/Query/PlanFormatter.cs
@@ -122,6 +122,16 @@ namespace Oracle.NoSQL.SDK.Query
                 case GroupStep group:
                     AppendGroupStep(builder, group, indent);
                     break;
+                case UnionStep union:
+                    for (var i = 0; i < union.BranchSteps.Length; i++)
+                    {
+                        AppendStep(builder, union.BranchSteps[i], indent);
+                        if (i < union.BranchSteps.Length - 1)
+                        {
+                            builder.Append(",\n");
+                        }
+                    }
+                    break;
             }
         }
 

--- a/Oracle.NoSQL.SDK/src/Query/PlanFormatter.cs
+++ b/Oracle.NoSQL.SDK/src/Query/PlanFormatter.cs
@@ -69,6 +69,26 @@ namespace Oracle.NoSQL.SDK.Query
                     "OP_ADD_SUB" : "OP_MULT_DIV";
             }
 
+            if (step is ValueCompareStep compare)
+            {
+                return GetQueryFunctionName(compare.FuncCode);
+            }
+
+            if (step is AndOrStep logical)
+            {
+                return GetQueryFunctionName(logical.FuncCode);
+            }
+
+            if (step is IsNullStep isNull)
+            {
+                return GetQueryFunctionName(isNull.FuncCode);
+            }
+
+            if (step is SeqAggregateStep sequenceAggregate)
+            {
+                return GetQueryFunctionName(sequenceAggregate.FuncCode);
+            }
+
             // Java names this iterator FN_COLLECT and emits distinctness in
             // its content instead of encoding it in the iterator name.
             return step is FuncCollectStep ? "FN_COLLECT" : step.Name;
@@ -123,16 +143,133 @@ namespace Oracle.NoSQL.SDK.Query
                     AppendGroupStep(builder, group, indent);
                     break;
                 case UnionStep union:
+                    Indent(builder, indent);
+                    builder.Append("\"branches\" : [\n");
                     for (var i = 0; i < union.BranchSteps.Length; i++)
                     {
-                        AppendStep(builder, union.BranchSteps[i], indent);
+                        AppendStep(builder, union.BranchSteps[i], indent + 2);
                         if (i < union.BranchSteps.Length - 1)
                         {
                             builder.Append(",\n");
                         }
                     }
+                    builder.Append('\n');
+                    Indent(builder, indent);
+                    builder.Append(']');
+                    if (union.SortSpecs != null && union.SortSpecs.Length > 0)
+                    {
+                        builder.Append(",\n");
+                        AppendUnionSortSpecs(builder, union.SortSpecs, indent);
+                    }
+                    break;
+                case ArrayConstructorStep array:
+                    Indent(builder, indent);
+                    builder.Append("\"conditional\" : ")
+                        .Append(array.IsConditional ? "true" : "false")
+                        .Append(",\n");
+                    AppendInputSteps(builder, array.ArgSteps, indent);
+                    break;
+                case ValueCompareStep compare:
+                    AppendInputStep(builder, compare.LeftStep, indent);
+                    AppendInputStep(builder, compare.RightStep, indent);
+                    break;
+                case AndOrStep logical:
+                    AppendInputSteps(builder, logical.ArgSteps, indent);
+                    break;
+                case CaseStep @case:
+                    AppendCase(builder, @case, indent);
+                    break;
+                case IsNullStep isNull:
+                    AppendInputStep(builder, isNull.InputStep, indent);
+                    break;
+                case SeqAggregateStep sequenceAggregate:
+                    AppendInputStep(builder, sequenceAggregate.InputStep,
+                        indent);
                     break;
             }
+        }
+
+        private static void AppendInputStep(StringBuilder builder,
+            PlanStep step, int indent)
+        {
+            Indent(builder, indent);
+            builder.Append("\"input iterator\" :\n");
+            AppendStep(builder, step, indent);
+        }
+
+        private static void AppendInputSteps(StringBuilder builder,
+            PlanStep[] steps, int indent)
+        {
+            Indent(builder, indent);
+            builder.Append("\"input iterators\" : [\n");
+            for (var i = 0; i < steps.Length; i++)
+            {
+                AppendStep(builder, steps[i], indent + 2);
+                if (i < steps.Length - 1)
+                {
+                    builder.Append(",\n");
+                }
+            }
+            builder.Append('\n');
+            Indent(builder, indent);
+            builder.Append(']');
+        }
+
+        private static void AppendSteps(StringBuilder builder,
+            PlanStep[] steps, int indent)
+        {
+            for (var i = 0; i < steps.Length; i++)
+            {
+                AppendStep(builder, steps[i], indent);
+                if (i < steps.Length - 1)
+                {
+                    builder.Append(",\n");
+                }
+            }
+        }
+
+        private static void AppendCase(StringBuilder builder, CaseStep step,
+            int indent)
+        {
+            Indent(builder, indent);
+            builder.Append("\"clauses\" : [\n");
+            for (var i = 0; i < step.ConditionSteps.Length; i++)
+            {
+                Indent(builder, indent + 2);
+                builder.Append("{\n");
+                Indent(builder, indent + 4);
+                builder.Append("\"when iterator\" :\n");
+                AppendStep(builder, step.ConditionSteps[i], indent + 4);
+                builder.Append(",\n");
+                Indent(builder, indent + 4);
+                builder.Append("\"then iterator\" :\n");
+                AppendStep(builder, step.ThenSteps[i], indent + 4);
+                builder.Append('\n');
+                Indent(builder, indent + 2);
+                builder.Append('}');
+                if (i < step.ConditionSteps.Length - 1 ||
+                    step.ElseStep != null)
+                {
+                    builder.Append(",\n");
+                }
+            }
+            if (step.ElseStep != null)
+            {
+                Indent(builder, indent + 2);
+                builder.Append("{\n");
+                Indent(builder, indent + 4);
+                builder.Append("\"else iterator\" :\n");
+                AppendStep(builder, step.ElseStep, indent + 4);
+                builder.Append('\n');
+                Indent(builder, indent + 2);
+                builder.Append('}').Append('\n');
+            }
+            else
+            {
+                builder.Append('\n');
+            }
+            Indent(builder, indent);
+            builder.Append(']');
         }
 
         private static void AppendSFW(StringBuilder builder, SFWStep sfw,
@@ -307,6 +444,32 @@ namespace Oracle.NoSQL.SDK.Query
             }
         }
 
+        private static string GetQueryFunctionName(QueryFuncCode code) =>
+            code switch
+            {
+                QueryFuncCode.And => "AND",
+                QueryFuncCode.Or => "OR",
+                QueryFuncCode.Equal => "EQUAL",
+                QueryFuncCode.NotEqual => "NOT_EQUAL",
+                QueryFuncCode.GreaterThan => "GREATER_THAN",
+                QueryFuncCode.GreaterOrEqual => "GREATER_OR_EQUAL",
+                QueryFuncCode.LessThan => "LESS_THAN",
+                QueryFuncCode.LessOrEqual => "LESS_OR_EQUAL",
+                QueryFuncCode.IsNull => "IS_NULL",
+                QueryFuncCode.IsNotNull => "IS_NOT_NULL",
+                QueryFuncCode.SeqCount => "FN_SEQ_COUNT",
+                QueryFuncCode.SeqSum => "FN_SEQ_SUM",
+                QueryFuncCode.SeqAverage => "FN_SEQ_AVG",
+                QueryFuncCode.SeqMin => "FN_SEQ_MIN",
+                QueryFuncCode.SeqMax => "FN_SEQ_MAX",
+                QueryFuncCode.SeqCountIgnoreNulls => "FN_SEQ_COUNT_I",
+                QueryFuncCode.SeqCountNumbersIgnoreNulls =>
+                    "FN_SEQ_COUNT_NUMBERS_I",
+                QueryFuncCode.SeqMinIgnoreNulls => "FN_SEQ_MIN_I",
+                QueryFuncCode.SeqMaxIgnoreNulls => "FN_SEQ_MAX_I",
+                _ => code.ToString()
+            };
+
         private static void AppendOptionalStep(StringBuilder builder,
             string label, PlanStep step, int indent)
         {
@@ -340,6 +503,30 @@ namespace Oracle.NoSQL.SDK.Query
                 }
             }
             builder.Append(",\n");
+        }
+
+        private static void AppendUnionSortSpecs(StringBuilder builder,
+            SortSpec[] specs, int indent)
+        {
+            Indent(builder, indent);
+            builder.Append("\"order by fields\" : [ ")
+                .AppendJoin(", ", System.Array.ConvertAll(specs,
+                    spec => spec.FieldName)).Append(" ],\n");
+            Indent(builder, indent);
+            builder.Append("\"sort specs\" : [ ");
+            for (var i = 0; i < specs.Length; i++)
+            {
+                if (i > 0)
+                {
+                    builder.Append(", ");
+                }
+                builder.Append("{ \"desc\" : ")
+                    .Append(specs[i].IsDescending ? "true" : "false")
+                    .Append(", \"nulls_first\" : ")
+                    .Append(specs[i].NullsFirst ? "true" : "false")
+                    .Append(" }");
+            }
+            builder.Append(" ]");
         }
 
         private static void AppendStringValues(StringBuilder builder,

--- a/Oracle.NoSQL.SDK/src/Query/PlanStep.cs
+++ b/Oracle.NoSQL.SDK/src/Query/PlanStep.cs
@@ -312,10 +312,27 @@ namespace Oracle.NoSQL.SDK.Query
 
         internal bool CountMemory { get; set; }
 
+        internal bool IsRegrouping { get; set; }
+
         internal override PlanAsyncIterator CreateAsyncIterator(
             QueryRuntime runtime)
         {
             return new GroupIterator(runtime, this);
+        }
+    }
+
+    internal class UnionStep : PlanAsyncStep
+    {
+        internal override string Name => "UNION";
+
+        internal PlanStep[] BranchSteps { get; set; }
+
+        internal SortSpec[] SortSpecs { get; set; }
+
+        internal override PlanAsyncIterator CreateAsyncIterator(
+            QueryRuntime runtime)
+        {
+            return new UnionIterator(runtime, this);
         }
     }
 

--- a/Oracle.NoSQL.SDK/src/Query/PlanStep.cs
+++ b/Oracle.NoSQL.SDK/src/Query/PlanStep.cs
@@ -34,6 +34,31 @@ namespace Oracle.NoSQL.SDK.Query
         ArrayCollectDistinct = 92
     }
 
+    // Function codes used by driver-side expression iterators in V6 plans.
+    // Keep these numeric values aligned with Java's FuncCode enum.
+    internal enum QueryFuncCode
+    {
+        And = 0,
+        Or = 1,
+        Equal = 2,
+        NotEqual = 3,
+        GreaterThan = 4,
+        GreaterOrEqual = 5,
+        LessThan = 6,
+        LessOrEqual = 7,
+        IsNull = 22,
+        IsNotNull = 23,
+        SeqCount = 49,
+        SeqSum = 50,
+        SeqAverage = 51,
+        SeqMin = 52,
+        SeqMax = 53,
+        SeqCountIgnoreNulls = 76,
+        SeqCountNumbersIgnoreNulls = 77,
+        SeqMinIgnoreNulls = 78,
+        SeqMaxIgnoreNulls = 79
+    }
+
     internal struct ExpressionLocation
     {
         internal int StartLine { get; set; }
@@ -293,6 +318,62 @@ namespace Oracle.NoSQL.SDK.Query
         {
             return new FuncSizeIterator(runtime, this);
         }
+    }
+
+    internal class ArrayConstructorStep : PlanSyncStep
+    {
+        internal override string Name => "ARRAY_CONSTRUCTOR";
+        internal bool IsConditional { get; set; }
+        internal PlanStep[] ArgSteps { get; set; }
+        internal override PlanSyncIterator CreateSyncIterator(
+            QueryRuntime runtime) => new ArrayConstructorIterator(runtime, this);
+    }
+
+    internal class ValueCompareStep : PlanSyncStep
+    {
+        internal override string Name => FuncCode.ToString();
+        internal QueryFuncCode FuncCode { get; set; }
+        internal PlanStep LeftStep { get; set; }
+        internal PlanStep RightStep { get; set; }
+        internal override PlanSyncIterator CreateSyncIterator(
+            QueryRuntime runtime) => new ValueCompareIterator(runtime, this);
+    }
+
+    internal class AndOrStep : PlanSyncStep
+    {
+        internal override string Name => FuncCode == QueryFuncCode.And ? "AND" : "OR";
+        internal QueryFuncCode FuncCode { get; set; }
+        internal PlanStep[] ArgSteps { get; set; }
+        internal override PlanSyncIterator CreateSyncIterator(
+            QueryRuntime runtime) => new AndOrIterator(runtime, this);
+    }
+
+    internal class CaseStep : PlanSyncStep
+    {
+        internal override string Name => "CASE";
+        internal PlanStep[] ConditionSteps { get; set; }
+        internal PlanStep[] ThenSteps { get; set; }
+        internal PlanStep ElseStep { get; set; }
+        internal override PlanSyncIterator CreateSyncIterator(
+            QueryRuntime runtime) => new CaseIterator(runtime, this);
+    }
+
+    internal class IsNullStep : PlanSyncStep
+    {
+        internal override string Name => FuncCode == QueryFuncCode.IsNull ? "IS_NULL" : "IS_NOT_NULL";
+        internal QueryFuncCode FuncCode { get; set; }
+        internal PlanStep InputStep { get; set; }
+        internal override PlanSyncIterator CreateSyncIterator(
+            QueryRuntime runtime) => new IsNullIterator(runtime, this);
+    }
+
+    internal class SeqAggregateStep : PlanSyncStep
+    {
+        internal override string Name => FuncCode.ToString();
+        internal QueryFuncCode FuncCode { get; set; }
+        internal PlanStep InputStep { get; set; }
+        internal override PlanSyncIterator CreateSyncIterator(
+            QueryRuntime runtime) => new SeqAggregateIterator(runtime, this);
     }
     internal class GroupStep : PlanAsyncStep
     {

--- a/Oracle.NoSQL.SDK/src/Query/PlanValidator.cs
+++ b/Oracle.NoSQL.SDK/src/Query/PlanValidator.cs
@@ -244,5 +244,22 @@ namespace Oracle.NoSQL.SDK.Query
             CheckStepExists(step.InputStep, "input", step);
         }
 
+        internal static void ValidateUnionStep(UnionStep step)
+        {
+            ValidateBase(step);
+            CheckNotEmpty(step.BranchSteps, "branch steps", step);
+            for (var i = 0; i < step.BranchSteps.Length; i++)
+            {
+                CheckStepExists(step.BranchSteps[i], "branch", step, i);
+                if (!step.BranchSteps[i].IsAsync)
+                {
+                    throw new BadProtocolException(
+                        "Query plan: unexpected sync step " +
+                        step.BranchSteps[i].Name +
+                        " for UNION branch " + i);
+                }
+            }
+        }
+
     }
 }

--- a/Oracle.NoSQL.SDK/src/Query/PlanValidator.cs
+++ b/Oracle.NoSQL.SDK/src/Query/PlanValidator.cs
@@ -261,5 +261,92 @@ namespace Oracle.NoSQL.SDK.Query
             }
         }
 
+        internal static void ValidateArrayConstructorStep(
+            ArrayConstructorStep step)
+        {
+            ValidateBase(step);
+            // Java permits ARRAY_CONSTRUCTOR with no arguments, which is the
+            // driver representation of an empty array literal.
+            CheckNotNull(step.ArgSteps, "argument steps", step);
+            for (var i = 0; i < step.ArgSteps.Length; i++)
+            {
+                CheckStepIsSync(step.ArgSteps[i], "argument", step, i);
+            }
+        }
+
+        internal static void ValidateValueCompareStep(ValueCompareStep step)
+        {
+            ValidateBase(step);
+            if (step.FuncCode < QueryFuncCode.Equal ||
+                step.FuncCode > QueryFuncCode.LessOrEqual)
+            {
+                throw new BadProtocolException(
+                    $"Query plan: invalid comparison function {step.FuncCode}");
+            }
+            CheckStepIsSync(step.LeftStep, "left operand", step);
+            CheckStepIsSync(step.RightStep, "right operand", step);
+        }
+
+        internal static void ValidateAndOrStep(AndOrStep step)
+        {
+            ValidateBase(step);
+            if (step.FuncCode != QueryFuncCode.And &&
+                step.FuncCode != QueryFuncCode.Or)
+            {
+                throw new BadProtocolException(
+                    $"Query plan: invalid logical function {step.FuncCode}");
+            }
+            CheckNotEmpty(step.ArgSteps, "argument steps", step);
+            for (var i = 0; i < step.ArgSteps.Length; i++)
+            {
+                CheckStepIsSync(step.ArgSteps[i], "argument", step, i);
+            }
+        }
+
+        internal static void ValidateCaseStep(CaseStep step)
+        {
+            ValidateBase(step);
+            CheckNotEmpty(step.ConditionSteps, "condition steps", step);
+            CheckNotEmpty(step.ThenSteps, "then steps", step);
+            if (step.ConditionSteps.Length != step.ThenSteps.Length)
+            {
+                throw new BadProtocolException(
+                    "Query plan: CASE has different numbers of conditions and then steps");
+            }
+            for (var i = 0; i < step.ConditionSteps.Length; i++)
+            {
+                CheckStepIsSync(step.ConditionSteps[i], "condition", step, i);
+                CheckStepIsSync(step.ThenSteps[i], "then", step, i);
+            }
+            if (step.ElseStep != null)
+            {
+                CheckStepIsSync(step.ElseStep, "else", step);
+            }
+        }
+
+        internal static void ValidateIsNullStep(IsNullStep step)
+        {
+            ValidateBase(step);
+            if (step.FuncCode != QueryFuncCode.IsNull &&
+                step.FuncCode != QueryFuncCode.IsNotNull)
+            {
+                throw new BadProtocolException(
+                    $"Query plan: invalid null-check function {step.FuncCode}");
+            }
+            CheckStepIsSync(step.InputStep, "input", step);
+        }
+
+        internal static void ValidateSeqAggregateStep(SeqAggregateStep step)
+        {
+            ValidateBase(step);
+            if (step.FuncCode < QueryFuncCode.SeqCount ||
+                step.FuncCode > QueryFuncCode.SeqMaxIgnoreNulls)
+            {
+                throw new BadProtocolException(
+                    $"Query plan: invalid sequence aggregate function {step.FuncCode}");
+            }
+            CheckStepIsSync(step.InputStep, "input", step);
+        }
+
     }
 }

--- a/Oracle.NoSQL.SDK/src/Query/QueryPlanExecutor.cs
+++ b/Oracle.NoSQL.SDK/src/Query/QueryPlanExecutor.cs
@@ -60,6 +60,8 @@ namespace Oracle.NoSQL.SDK.Query {
 
         internal bool FetchDone { get; set; }
 
+        internal int UnionBranch { get; set; }
+
         internal bool NeedContinuation
         {
             get => continuationKey != null;

--- a/Oracle.NoSQL.SDK/src/Query/QueryPlanExecutor.cs
+++ b/Oracle.NoSQL.SDK/src/Query/QueryPlanExecutor.cs
@@ -36,6 +36,12 @@ namespace Oracle.NoSQL.SDK.Query {
 
         internal TopologyInfo BaseTopology { get; }
 
+        private readonly TopologyInfo[] branchTopologies;
+
+        // Set while UnionIterator constructs a branch. ReceiveIterator uses
+        // this frozen snapshot rather than looking up a mutable client cache.
+        internal int ConstructionUnionBranch { get; set; } = -1;
+
         internal long MaxMemory { get; set; }
 
         // Used only for error reporting
@@ -103,7 +109,22 @@ namespace Oracle.NoSQL.SDK.Query {
             }
 
             BaseTopology = client.QueryTopology;
+            if (preparedStatement.QueryBranches.Count > 1)
+            {
+                branchTopologies = new TopologyInfo[
+                    preparedStatement.QueryBranches.Count];
+                for (var i = 0; i < branchTopologies.Length; i++)
+                {
+                    branchTopologies[i] = client.GetQueryTopology(
+                        preparedStatement.GetStoreName(i));
+                }
+            }
         }
+
+        internal TopologyInfo GetConstructionTopology() =>
+            ConstructionUnionBranch >= 0 && branchTopologies != null
+                ? branchTopologies[ConstructionUnionBranch]
+                : BaseTopology;
 
         private void InitExternalVariables()
         {

--- a/Oracle.NoSQL.SDK/src/Query/QueryPlanExecutor.cs
+++ b/Oracle.NoSQL.SDK/src/Query/QueryPlanExecutor.cs
@@ -36,6 +36,8 @@ namespace Oracle.NoSQL.SDK.Query {
 
         internal TopologyInfo BaseTopology { get; }
 
+        internal IReadOnlyList<TopologyInfo> StoreTopologies { get; }
+
         private readonly TopologyInfo[] branchTopologies;
 
         // Set while UnionIterator constructs a branch. ReceiveIterator uses
@@ -109,6 +111,7 @@ namespace Oracle.NoSQL.SDK.Query {
             }
 
             BaseTopology = client.QueryTopology;
+            StoreTopologies = client.StoreTopologies;
             if (preparedStatement.QueryBranches.Count > 1)
             {
                 branchTopologies = new TopologyInfo[

--- a/Oracle.NoSQL.SDK/src/Query/ReceiveIterator.cs
+++ b/Oracle.NoSQL.SDK/src/Query/ReceiveIterator.cs
@@ -112,6 +112,7 @@ namespace Oracle.NoSQL.SDK.Query {
 
             queryRequest.ShardId = shardId;
             queryRequest.VirtualScan = virtualScan;
+            queryRequest.UnionBranch = runtime.UnionBranch;
             queryRequest.StatsLogicalQueryRequest = runtime.Request;
 
             var result = (QueryResult<RecordValue>)

--- a/Oracle.NoSQL.SDK/src/Query/ReceiveIterator.cs
+++ b/Oracle.NoSQL.SDK/src/Query/ReceiveIterator.cs
@@ -45,7 +45,7 @@ namespace Oracle.NoSQL.SDK.Query {
                     QueryLabel = runtime.Request.Options?.QueryLabel
                 })
             {
-                BaseTopology = runtime.BaseTopology,
+                BaseTopology = runtime.GetConstructionTopology(),
                 IsInternal = true
             };
 
@@ -58,7 +58,7 @@ namespace Oracle.NoSQL.SDK.Query {
             {
                 if (step.DistributionKind == DistributionKind.AllShards)
                 {
-                    var topologyInfo = runtime.BaseTopology;
+                    var topologyInfo = queryRequest.BaseTopology;
                     
                     if (topologyInfo == null)
                     {
@@ -115,6 +115,16 @@ namespace Oracle.NoSQL.SDK.Query {
             queryRequest.UnionBranch = runtime.UnionBranch;
             queryRequest.StatsLogicalQueryRequest = runtime.Request;
 
+            if (queryRequest.Options.TraceLevel.HasValue)
+            {
+                // Internal UNION branch requests belong to one logical query,
+                // so the trace counter must advance globally, not per branch.
+                // NSON converts this zero-based value to Java's one-based
+                // batch counter when it writes the request.
+                queryRequest.Options.BatchNumber =
+                    runtime.Request.Options.BatchNumber++;
+            }
+
             var result = (QueryResult<RecordValue>)
                 await runtime.Client.ExecuteValidatedRequestAsync(
                     queryRequest, cancellationToken);
@@ -145,7 +155,6 @@ namespace Oracle.NoSQL.SDK.Query {
             if (result.QueryTraces != null)
             {
                 runtime.AddServerQueryTraces(result.QueryTraces);
-                queryRequest.Options.BatchNumber++;
             }
 
             return result;
@@ -337,7 +346,7 @@ namespace Oracle.NoSQL.SDK.Query {
         {
             if (currVScanId == -1)
             {
-                var topologyInfo = runtime.BaseTopology;
+                var topologyInfo = queryRequest.BaseTopology;
                 Debug.Assert(topologyInfo?.ShardIds?.Count != 0);
                 // ShardIds are sorted.
                 currVScanId = topologyInfo!.ShardIds![^1] + 1;

--- a/Oracle.NoSQL.SDK/src/Query/ReceiveIterator.cs
+++ b/Oracle.NoSQL.SDK/src/Query/ReceiveIterator.cs
@@ -35,6 +35,7 @@ namespace Oracle.NoSQL.SDK.Query {
                 new QueryOptions
                 {
                     Compartment = runtime.Request.Options?.Compartment,
+                    Namespace = runtime.Request.Options?.Namespace,
                     Timeout = runtime.Request.Options?.Timeout,
                     Consistency = runtime.Request.Options?.Consistency,
                     LastWriteMetadata =
@@ -46,6 +47,7 @@ namespace Oracle.NoSQL.SDK.Query {
                 })
             {
                 BaseTopology = runtime.GetConstructionTopology(),
+                StoreTopologySnapshot = runtime.StoreTopologies,
                 IsInternal = true
             };
 

--- a/Oracle.NoSQL.SDK/src/Query/UnionIterator.cs
+++ b/Oracle.NoSQL.SDK/src/Query/UnionIterator.cs
@@ -1,0 +1,178 @@
+/*-
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ * https://oss.oracle.com/licenses/upl/
+ */
+
+namespace Oracle.NoSQL.SDK.Query
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using static Utils;
+
+    internal class UnionIterator : PlanAsyncIterator
+    {
+        private sealed class Branch
+        {
+            internal PlanAsyncIterator Iterator { get; }
+            internal RecordValue Current { get; set; }
+            internal bool IsDone { get; set; }
+            internal bool IsStarted { get; set; }
+
+            internal Branch(PlanAsyncIterator iterator)
+            {
+                Iterator = iterator;
+            }
+        }
+
+        private readonly UnionStep step;
+        private readonly Branch[] branches;
+        private int currentBranch;
+
+        internal UnionIterator(QueryRuntime runtime, UnionStep step) :
+            base(runtime)
+        {
+            this.step = step;
+            if (runtime.PreparedStatement.QueryBranches.Count !=
+                step.BranchSteps.Length)
+            {
+                throw new BadProtocolException(
+                    "Query: number of UNION plan branches does not match " +
+                    "the number of proxy prepared statements");
+            }
+
+            branches = new Branch[step.BranchSteps.Length];
+            for (var i = 0; i < branches.Length; i++)
+            {
+                branches[i] = new Branch(step.BranchSteps[i]
+                    .CreateAsyncIterator(runtime));
+            }
+        }
+
+        private async Task<bool> FetchBranchAsync(int branch,
+            CancellationToken cancellationToken)
+        {
+            var state = branches[branch];
+            if (state.IsDone || state.Current != null)
+            {
+                return state.Current != null;
+            }
+
+            var wasStarted = state.IsStarted;
+            state.IsStarted = true;
+            runtime.UnionBranch = branch;
+            if (!await state.Iterator.NextAsync(cancellationToken))
+            {
+                // ReceiveIterator intentionally returns false without setting
+                // NeedContinuation when a second, not-yet-started iterator
+                // is blocked by this batch's one-server-fetch limit. For a
+                // UNION branch that means defer the branch, not completion.
+                if (!wasStarted && runtime.FetchDone &&
+                    !runtime.NeedContinuation)
+                {
+                    runtime.NeedContinuation = true;
+                    return false;
+                }
+
+                if (!runtime.NeedContinuation)
+                {
+                    state.IsDone = true;
+                }
+                return false;
+            }
+
+            if (!(state.Iterator.Result is RecordValue row))
+            {
+                throw new InvalidOperationException(
+                    "Query: UNION branch result is not a record value: " +
+                    state.Iterator.Result);
+            }
+
+            state.Current = row;
+            return true;
+        }
+
+        private async Task<bool> NextSequentialAsync(
+            CancellationToken cancellationToken)
+        {
+            while (currentBranch < branches.Length)
+            {
+                if (await FetchBranchAsync(currentBranch, cancellationToken))
+                {
+                    Result = branches[currentBranch].Current;
+                    branches[currentBranch].Current = null;
+                    return true;
+                }
+
+                if (runtime.NeedContinuation)
+                {
+                    return false;
+                }
+
+                ++currentBranch;
+                if (currentBranch < branches.Length)
+                {
+                    runtime.UnionBranch = currentBranch;
+                    runtime.NeedContinuation = true;
+                    return false;
+                }
+            }
+
+            return false;
+        }
+
+        private async Task<bool> NextSortedAsync(
+            CancellationToken cancellationToken)
+        {
+            for (var i = 0; i < branches.Length; i++)
+            {
+                if (!branches[i].IsDone && branches[i].Current == null)
+                {
+                    await FetchBranchAsync(i, cancellationToken);
+                    if (runtime.NeedContinuation)
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            var selected = -1;
+            for (var i = 0; i < branches.Length; i++)
+            {
+                var row = branches[i].Current;
+                if (row == null)
+                {
+                    continue;
+                }
+
+                if (selected < 0 || CompareRows(row,
+                        branches[selected].Current, step.SortSpecs) < 0)
+                {
+                    selected = i;
+                }
+            }
+
+            if (selected < 0)
+            {
+                return false;
+            }
+
+            runtime.UnionBranch = selected;
+            Result = branches[selected].Current;
+            branches[selected].Current = null;
+            return true;
+        }
+
+        internal override async Task<bool> NextAsync(
+            CancellationToken cancellationToken)
+        {
+            return step.SortSpecs == null
+                ? await NextSequentialAsync(cancellationToken)
+                : await NextSortedAsync(cancellationToken);
+        }
+
+        internal override PlanStep Step => step;
+    }
+}

--- a/Oracle.NoSQL.SDK/src/Query/UnionIterator.cs
+++ b/Oracle.NoSQL.SDK/src/Query/UnionIterator.cs
@@ -63,6 +63,17 @@ namespace Oracle.NoSQL.SDK.Query
             var wasStarted = state.IsStarted;
             state.IsStarted = true;
             runtime.UnionBranch = branch;
+
+            // Each user Query call permits only one proxy fetch. Defer an
+            // unstarted branch before its ReceiveIterator enters sort phase
+            // 1, which expects the continuation requirement to be recorded.
+            if (!wasStarted && runtime.FetchDone &&
+                !runtime.NeedContinuation)
+            {
+                runtime.NeedContinuation = true;
+                return false;
+            }
+
             if (!await state.Iterator.NextAsync(cancellationToken))
             {
                 // ReceiveIterator intentionally returns false without setting

--- a/Oracle.NoSQL.SDK/src/Query/UnionIterator.cs
+++ b/Oracle.NoSQL.SDK/src/Query/UnionIterator.cs
@@ -46,8 +46,17 @@ namespace Oracle.NoSQL.SDK.Query
             branches = new Branch[step.BranchSteps.Length];
             for (var i = 0; i < branches.Length; i++)
             {
-                branches[i] = new Branch(step.BranchSteps[i]
-                    .CreateAsyncIterator(runtime));
+                var savedBranch = runtime.ConstructionUnionBranch;
+                runtime.ConstructionUnionBranch = i;
+                try
+                {
+                    branches[i] = new Branch(step.BranchSteps[i]
+                        .CreateAsyncIterator(runtime));
+                }
+                finally
+                {
+                    runtime.ConstructionUnionBranch = savedBranch;
+                }
             }
         }
 

--- a/Oracle.NoSQL.SDK/src/Query/V6ValueIterators.cs
+++ b/Oracle.NoSQL.SDK/src/Query/V6ValueIterators.cs
@@ -1,0 +1,711 @@
+/*-
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ *  https://oss.oracle.com/licenses/upl/
+ */
+
+namespace Oracle.NoSQL.SDK.Query
+{
+    using System;
+    using System.Collections.Generic;
+    using static V6IteratorUtils;
+
+    internal class ArrayConstructorIterator : OneResultIterator
+    {
+        private readonly ArrayConstructorStep step;
+        private readonly PlanSyncIterator[] arguments;
+
+        internal ArrayConstructorIterator(QueryRuntime runtime,
+            ArrayConstructorStep step) : base(runtime)
+        {
+            this.step = step;
+            arguments = CreateIterators(runtime, step.ArgSteps);
+        }
+
+        internal override bool Next()
+        {
+            if (done)
+            {
+                return false;
+            }
+
+            ArrayValue result;
+            if (step.IsConditional)
+            {
+                if (!arguments[0].Next())
+                {
+                    done = true;
+                    return false;
+                }
+
+                var first = arguments[0].Result;
+                if (!arguments[0].Next())
+                {
+                    Result = first;
+                    done = true;
+                    return true;
+                }
+
+                result = new ArrayValue();
+                AddIfNotNull(result, first);
+                AddIfNotNull(result, arguments[0].Result);
+            }
+            else
+            {
+                result = new ArrayValue();
+            }
+
+            foreach (var iterator in arguments)
+            {
+                while (iterator.Next())
+                {
+                    AddIfNotNull(result, iterator.Result);
+                }
+            }
+
+            Result = result;
+            done = true;
+            return true;
+        }
+
+        internal override void Reset(bool resetResult = false)
+        {
+            base.Reset(resetResult);
+            ResetIterators(arguments, resetResult);
+        }
+
+        internal override PlanStep Step => step;
+
+        private static void AddIfNotNull(ArrayValue result, FieldValue value)
+        {
+            if (value != FieldValue.Null)
+            {
+                result.Add(value);
+            }
+        }
+    }
+
+    internal class IsNullIterator : OneResultIterator
+    {
+        private readonly IsNullStep step;
+        private readonly PlanSyncIterator input;
+
+        internal IsNullIterator(QueryRuntime runtime, IsNullStep step) :
+            base(runtime)
+        {
+            this.step = step;
+            input = step.InputStep.CreateSyncIterator(runtime);
+        }
+
+        internal override bool Next()
+        {
+            if (done)
+            {
+                return false;
+            }
+
+            var isNull = input.Next() && input.Result == FieldValue.Null;
+            Result = step.FuncCode == QueryFuncCode.IsNull
+                ? (isNull ? BooleanValue.True : BooleanValue.False)
+                : (isNull ? BooleanValue.False : BooleanValue.True);
+            done = true;
+            return true;
+        }
+
+        internal override void Reset(bool resetResult = false)
+        {
+            base.Reset(resetResult);
+            input.Reset(resetResult);
+        }
+
+        internal override PlanStep Step => step;
+    }
+
+    internal class AndOrIterator : OneResultIterator
+    {
+        private readonly AndOrStep step;
+        private readonly PlanSyncIterator[] arguments;
+
+        internal AndOrIterator(QueryRuntime runtime, AndOrStep step) :
+            base(runtime)
+        {
+            this.step = step;
+            arguments = CreateIterators(runtime, step.ArgSteps);
+        }
+
+        internal override bool Next()
+        {
+            if (done)
+            {
+                return false;
+            }
+
+            var isAnd = step.FuncCode == QueryFuncCode.And;
+            var result = isAnd;
+            var hasNull = false;
+            foreach (var iterator in arguments)
+            {
+                if (!iterator.Next())
+                {
+                    result = isAnd ? false : result;
+                }
+                else if (iterator.Result == FieldValue.Null)
+                {
+                    hasNull = true;
+                    continue;
+                }
+                else
+                {
+                    var value = iterator.Result.AsBoolean;
+                    result = isAnd ? result && value : result || value;
+                }
+
+                if (isAnd ? !result : result)
+                {
+                    hasNull = false;
+                    break;
+                }
+            }
+
+            Result = hasNull ? FieldValue.Null :
+                (result ? BooleanValue.True : BooleanValue.False);
+            done = true;
+            return true;
+        }
+
+        internal override void Reset(bool resetResult = false)
+        {
+            base.Reset(resetResult);
+            ResetIterators(arguments, resetResult);
+        }
+
+        internal override PlanStep Step => step;
+    }
+
+    internal class CaseIterator : PlanSyncIterator
+    {
+        private readonly CaseStep step;
+        private readonly PlanSyncIterator[] conditions;
+        private readonly PlanSyncIterator[] thenSteps;
+        private readonly PlanSyncIterator elseStep;
+        private PlanSyncIterator activeStep;
+        private bool done;
+
+        internal CaseIterator(QueryRuntime runtime, CaseStep step) : base(runtime)
+        {
+            this.step = step;
+            conditions = CreateIterators(runtime, step.ConditionSteps);
+            thenSteps = CreateIterators(runtime, step.ThenSteps);
+            elseStep = step.ElseStep?.CreateSyncIterator(runtime);
+        }
+
+        internal override bool Next()
+        {
+            if (done)
+            {
+                return false;
+            }
+
+            if (activeStep == null)
+            {
+                for (var i = 0; i < conditions.Length; i++)
+                {
+                    if (conditions[i].Next() &&
+                        conditions[i].Result != FieldValue.Null &&
+                        conditions[i].Result.AsBoolean)
+                    {
+                        activeStep = thenSteps[i];
+                        break;
+                    }
+                }
+                activeStep ??= elseStep;
+                if (activeStep == null)
+                {
+                    done = true;
+                    return false;
+                }
+            }
+
+            if (!activeStep.Next())
+            {
+                done = true;
+                return false;
+            }
+
+            Result = activeStep.Result;
+            return true;
+        }
+
+        internal override void Reset(bool resetResult = false)
+        {
+            done = false;
+            activeStep = null;
+            ResetIterators(conditions, resetResult);
+            ResetIterators(thenSteps, resetResult);
+            elseStep?.Reset(resetResult);
+        }
+
+        internal override PlanStep Step => step;
+    }
+
+    internal class ValueCompareIterator : OneResultIterator
+    {
+        private readonly ValueCompareStep step;
+        private readonly PlanSyncIterator left;
+        private readonly PlanSyncIterator right;
+
+        internal ValueCompareIterator(QueryRuntime runtime,
+            ValueCompareStep step) : base(runtime)
+        {
+            this.step = step;
+            left = step.LeftStep.CreateSyncIterator(runtime);
+            right = step.RightStep.CreateSyncIterator(runtime);
+        }
+
+        internal override bool Next()
+        {
+            if (done)
+            {
+                return false;
+            }
+
+            var hasLeft = left.Next();
+            var leftValue = hasLeft ? left.Result : null;
+            if (hasLeft && left.Next())
+            {
+                throw new InvalidOperationException(GetMessageWithLocation(
+                    "The left comparison operand is a sequence with more than one item"));
+            }
+            var hasRight = right.Next();
+            var rightValue = hasRight ? right.Result : null;
+            if (hasRight && right.Next())
+            {
+                throw new InvalidOperationException(GetMessageWithLocation(
+                    "The right comparison operand is a sequence with more than one item"));
+            }
+
+            var comparison = new ComparisonResult();
+            if (!hasLeft && !hasRight)
+            {
+                comparison.Value = 0;
+            }
+            else if (!hasLeft || !hasRight)
+            {
+                if (step.FuncCode == QueryFuncCode.NotEqual)
+                {
+                    comparison.Value = 1;
+                }
+                else
+                {
+                    comparison.Incompatible = true;
+                }
+            }
+            else
+            {
+                CompareValues(leftValue, rightValue, comparison);
+            }
+
+            Result = comparison.HasNull ? FieldValue.Null :
+                comparison.Incompatible ? BooleanValue.False :
+                (ApplyComparison(comparison.Value) ? BooleanValue.True :
+                    BooleanValue.False);
+            done = true;
+            return true;
+        }
+
+        internal override void Reset(bool resetResult = false)
+        {
+            base.Reset(resetResult);
+            left.Reset(resetResult);
+            right.Reset(resetResult);
+        }
+
+        internal override PlanStep Step => step;
+
+        private void CompareValues(FieldValue leftValue, FieldValue rightValue,
+            ComparisonResult result)
+        {
+            result.Clear();
+            if (leftValue == FieldValue.Null || rightValue == FieldValue.Null)
+            {
+                result.HasNull = true;
+                return;
+            }
+            if (leftValue.DbType == DbType.JsonNull ||
+                rightValue.DbType == DbType.JsonNull)
+            {
+                var bothJsonNull = leftValue.DbType == DbType.JsonNull &&
+                    rightValue.DbType == DbType.JsonNull;
+                if (bothJsonNull)
+                {
+                    result.Value = 0;
+                }
+                else if (step.FuncCode == QueryFuncCode.NotEqual)
+                {
+                    result.Value = 1;
+                }
+                else
+                {
+                    result.Incompatible = true;
+                }
+                return;
+            }
+
+            if (leftValue.DbType == DbType.Empty ||
+                rightValue.DbType == DbType.Empty)
+            {
+                if (leftValue.DbType == DbType.Empty &&
+                    rightValue.DbType == DbType.Empty &&
+                    (step.FuncCode == QueryFuncCode.Equal ||
+                     step.FuncCode == QueryFuncCode.GreaterOrEqual ||
+                     step.FuncCode == QueryFuncCode.LessOrEqual))
+                {
+                    result.Value = 0;
+                }
+                else if (leftValue.DbType != rightValue.DbType &&
+                         step.FuncCode == QueryFuncCode.NotEqual)
+                {
+                    result.Value = 1;
+                }
+                else
+                {
+                    result.Incompatible = true;
+                }
+                return;
+            }
+
+            var leftType = leftValue.DbType;
+            var rightType = rightValue.DbType;
+            if (leftValue.IsNumeric && rightValue.IsNumeric)
+            {
+                result.Value = leftValue.QueryCompare(rightValue);
+                return;
+            }
+            if ((leftType == DbType.String || leftType == DbType.Timestamp) &&
+                (rightType == DbType.String || rightType == DbType.Timestamp))
+            {
+                result.Value = string.CompareOrdinal(
+                    GetStringValue(leftValue), GetStringValue(rightValue));
+                return;
+            }
+            if (leftType == DbType.Boolean && rightType == DbType.Boolean)
+            {
+                result.Value = leftValue.QueryCompare(rightValue);
+                return;
+            }
+            if (leftType == DbType.Binary && rightType == DbType.Binary)
+            {
+                if (step.FuncCode == QueryFuncCode.Equal ||
+                    step.FuncCode == QueryFuncCode.NotEqual)
+                {
+                    result.Value = leftValue.QueryEquals(rightValue) ? 0 : 1;
+                }
+                else
+                {
+                    result.Incompatible = true;
+                }
+                return;
+            }
+            if (leftType == DbType.Map && rightType == DbType.Map)
+            {
+                if (step.FuncCode == QueryFuncCode.Equal ||
+                    step.FuncCode == QueryFuncCode.NotEqual)
+                {
+                    CompareMaps(leftValue.AsMapValue, rightValue.AsMapValue,
+                        result);
+                }
+                else
+                {
+                    result.Incompatible = true;
+                }
+                return;
+            }
+            if (leftType == DbType.Array && rightType == DbType.Array)
+            {
+                CompareArrays(leftValue.AsArrayValue, rightValue.AsArrayValue,
+                    result);
+                return;
+            }
+            result.Incompatible = true;
+        }
+
+        private static string GetStringValue(FieldValue value) =>
+            value.DbType == DbType.String ? value.AsString :
+            value.ToJsonString().Trim('"');
+
+        private void CompareMaps(MapValue leftValue, MapValue rightValue,
+            ComparisonResult result)
+        {
+            if (leftValue.Count != rightValue.Count)
+            {
+                result.Value = 1;
+                return;
+            }
+
+            foreach (var pair in leftValue)
+            {
+                if (!rightValue.TryGetValue(pair.Key, out var rightItem))
+                {
+                    result.Value = 1;
+                    return;
+                }
+
+                CompareValues(pair.Value, rightItem, result);
+                if (result.Value != 0 || result.HasNull ||
+                    result.Incompatible)
+                {
+                    return;
+                }
+            }
+        }
+
+        private void CompareArrays(ArrayValue leftValue, ArrayValue rightValue,
+            ComparisonResult result)
+        {
+            if ((step.FuncCode == QueryFuncCode.Equal ||
+                 step.FuncCode == QueryFuncCode.NotEqual) &&
+                leftValue.Count != rightValue.Count)
+            {
+                result.Value = 1;
+                return;
+            }
+
+            var count = Math.Min(leftValue.Count, rightValue.Count);
+            for (var i = 0; i < count; i++)
+            {
+                CompareValues(leftValue[i], rightValue[i], result);
+                if (result.Value != 0 || result.HasNull || result.Incompatible)
+                {
+                    return;
+                }
+            }
+
+            result.Value = leftValue.Count.CompareTo(rightValue.Count);
+        }
+
+        private bool ApplyComparison(int comparison) => step.FuncCode switch
+        {
+            QueryFuncCode.Equal => comparison == 0,
+            QueryFuncCode.NotEqual => comparison != 0,
+            QueryFuncCode.GreaterThan => comparison > 0,
+            QueryFuncCode.GreaterOrEqual => comparison >= 0,
+            QueryFuncCode.LessThan => comparison < 0,
+            QueryFuncCode.LessOrEqual => comparison <= 0,
+            _ => throw new InvalidOperationException()
+        };
+
+        private sealed class ComparisonResult
+        {
+            internal int Value { get; set; }
+            internal bool Incompatible { get; set; }
+            internal bool HasNull { get; set; }
+
+            internal void Clear()
+            {
+                Value = 0;
+                Incompatible = false;
+                HasNull = false;
+            }
+        }
+    }
+
+    internal class SeqAggregateIterator : OneResultIterator
+    {
+        private readonly SeqAggregateStep step;
+        private readonly PlanSyncIterator input;
+
+        internal SeqAggregateIterator(QueryRuntime runtime,
+            SeqAggregateStep step) : base(runtime)
+        {
+            this.step = step;
+            input = step.InputStep.CreateSyncIterator(runtime);
+        }
+
+        internal override bool Next()
+        {
+            if (done)
+            {
+                return false;
+            }
+
+            long count = 0;
+            var sumType = DbType.Long;
+            long longSum = 0;
+            double doubleSum = 0;
+            decimal numberSum = 0;
+            FieldValue minMax = null;
+            var sawValue = false;
+            var hasInput = false;
+            while (input.Next())
+            {
+                hasInput = true;
+                var value = input.Result;
+                switch (step.FuncCode)
+                {
+                    case QueryFuncCode.SeqCount:
+                        if (value == FieldValue.Null)
+                        {
+                            Result = FieldValue.Null;
+                            done = true;
+                            return true;
+                        }
+                        ++count;
+                        break;
+                    case QueryFuncCode.SeqCountIgnoreNulls:
+                        if (value != FieldValue.Null) ++count;
+                        break;
+                    case QueryFuncCode.SeqCountNumbersIgnoreNulls:
+                        if (value.IsNumeric) ++count;
+                        break;
+                    case QueryFuncCode.SeqSum:
+                    case QueryFuncCode.SeqAverage:
+                        if (value.IsNumeric)
+                        {
+                            AddToSum(value, ref sumType, ref longSum,
+                                ref doubleSum, ref numberSum);
+                            ++count;
+                        }
+                        break;
+                    default:
+                        if (value == FieldValue.Null &&
+                            (step.FuncCode == QueryFuncCode.SeqMin ||
+                             step.FuncCode == QueryFuncCode.SeqMax))
+                        {
+                            Result = FieldValue.Null;
+                            done = true;
+                            return true;
+                        }
+                        if (!value.IsSpecial && value.SupportsComparison)
+                        {
+                            if (!sawValue || (step.FuncCode == QueryFuncCode.SeqMin ||
+                                              step.FuncCode == QueryFuncCode.SeqMinIgnoreNulls
+                                ? value.QueryCompare(minMax) < 0
+                                : value.QueryCompare(minMax) > 0))
+                            {
+                                minMax = value;
+                            }
+                            sawValue = true;
+                        }
+                        break;
+                }
+            }
+
+            if (!hasInput && step.FuncCode != QueryFuncCode.SeqCount &&
+                step.FuncCode != QueryFuncCode.SeqCountIgnoreNulls)
+            {
+                done = true;
+                return false;
+            }
+
+            Result = step.FuncCode switch
+            {
+                QueryFuncCode.SeqCount or QueryFuncCode.SeqCountIgnoreNulls or
+                    QueryFuncCode.SeqCountNumbersIgnoreNulls => new LongValue(count),
+                QueryFuncCode.SeqSum => count == 0 ? FieldValue.Null :
+                    GetSum(sumType, longSum, doubleSum, numberSum),
+                QueryFuncCode.SeqAverage => count == 0 ? FieldValue.Null :
+                    sumType == DbType.Number
+                        ? new NumberValue(numberSum / count)
+                        : new DoubleValue((sumType == DbType.Long
+                            ? longSum : doubleSum) / count),
+                _ => minMax ?? FieldValue.Null
+            };
+            done = true;
+            return true;
+        }
+
+        internal override void Reset(bool resetResult = false)
+        {
+            base.Reset(resetResult);
+            input.Reset(resetResult);
+        }
+
+        internal override PlanStep Step => step;
+
+        private static void AddToSum(FieldValue value, ref DbType sumType,
+            ref long longSum, ref double doubleSum, ref decimal numberSum)
+        {
+            switch (value.DbType)
+            {
+                case DbType.Integer:
+                case DbType.Long:
+                    if (sumType == DbType.Long)
+                    {
+                        longSum = unchecked(longSum + value.ToInt64());
+                    }
+                    else if (sumType == DbType.Double)
+                    {
+                        doubleSum += value.ToDouble();
+                    }
+                    else
+                    {
+                        numberSum += value.ToDecimal();
+                    }
+                    break;
+                case DbType.Double:
+                    if (sumType == DbType.Long)
+                    {
+                        doubleSum = longSum + value.AsDouble;
+                        sumType = DbType.Double;
+                    }
+                    else if (sumType == DbType.Double)
+                    {
+                        doubleSum += value.AsDouble;
+                    }
+                    else
+                    {
+                        numberSum += (decimal)value.AsDouble;
+                    }
+                    break;
+                case DbType.Number:
+                    if (sumType == DbType.Long)
+                    {
+                        numberSum = longSum + value.AsDecimal;
+                    }
+                    else if (sumType == DbType.Double)
+                    {
+                        numberSum = (decimal)doubleSum + value.AsDecimal;
+                    }
+                    else
+                    {
+                        numberSum += value.AsDecimal;
+                    }
+                    sumType = DbType.Number;
+                    break;
+            }
+        }
+
+        private static FieldValue GetSum(DbType sumType, long longSum,
+            double doubleSum, decimal numberSum) => sumType switch
+        {
+            DbType.Long => new LongValue(longSum),
+            DbType.Double => new DoubleValue(doubleSum),
+            DbType.Number => new NumberValue(numberSum),
+            _ => throw new InvalidOperationException()
+        };
+    }
+
+    internal static class V6IteratorUtils
+    {
+        internal static PlanSyncIterator[] CreateIterators(QueryRuntime runtime,
+            PlanStep[] steps)
+        {
+            var result = new PlanSyncIterator[steps.Length];
+            for (var i = 0; i < steps.Length; i++)
+            {
+                result[i] = steps[i].CreateSyncIterator(runtime);
+            }
+            return result;
+        }
+
+        internal static void ResetIterators(IEnumerable<PlanSyncIterator> iterators,
+            bool resetResult)
+        {
+            foreach (var iterator in iterators)
+            {
+                iterator.Reset(resetResult);
+            }
+        }
+    }
+}

--- a/Oracle.NoSQL.SDK/src/Query/ValueAggregators.cs
+++ b/Oracle.NoSQL.SDK/src/Query/ValueAggregators.cs
@@ -159,6 +159,7 @@ namespace Oracle.NoSQL.SDK.Query
     internal abstract class CollectAggregatorBase : ValueAggregator
     {
         private protected readonly bool toSortResults;
+        private protected readonly bool isRegrouping;
 
         private protected abstract void AddValue(FieldValue value);
         
@@ -175,9 +176,11 @@ namespace Oracle.NoSQL.SDK.Query
         private protected override FieldValue GetInitialValue() =>
             new ArrayValue();
 
-        private protected CollectAggregatorBase(bool toSortResults)
+        private protected CollectAggregatorBase(bool toSortResults,
+            bool isRegrouping)
         {
             this.toSortResults = toSortResults;
+            this.isRegrouping = isRegrouping;
         }
 
         internal override long Aggregate(FieldValue value, bool countMemory)
@@ -187,11 +190,17 @@ namespace Oracle.NoSQL.SDK.Query
                 return 0;
             }
 
+            if (!isRegrouping)
+            {
+                AddValue(value);
+                return countMemory ? GetMemorySize(value.GetMemorySize()) : 0;
+            }
+
             if (!(value is ArrayValue))
             {
                 throw new InvalidOperationException(
-                    "Query: input value for array_collect is not an " +
-                    "ArrayValue");
+                    "Query: regrouped input value for array_collect is not " +
+                    "an ArrayValue");
             }
 
             long mem = 0;
@@ -201,7 +210,7 @@ namespace Oracle.NoSQL.SDK.Query
                 AddValue(elem);
                 if (countMemory)
                 {
-                    mem += GetMemorySize(value.GetMemorySize());
+                    mem += GetMemorySize(elem.GetMemorySize());
                 }
             }
 
@@ -223,7 +232,8 @@ namespace Oracle.NoSQL.SDK.Query
         private protected override long GetMemorySize(long valueSize) =>
             GetListEntrySize(valueSize);
 
-        internal CollectAggregator(bool toSortResults) : base(toSortResults)
+        internal CollectAggregator(bool toSortResults, bool isRegrouping) :
+            base(toSortResults, isRegrouping)
         {
         }
     }
@@ -242,8 +252,8 @@ namespace Oracle.NoSQL.SDK.Query
         private protected override long GetMemorySize(long valueSize) =>
             GetHashSetEntrySize(valueSize);
 
-        internal CollectDistinctAggregator(bool toSortResults) :
-            base(toSortResults)
+        internal CollectDistinctAggregator(bool toSortResults,
+            bool isRegrouping) : base(toSortResults, isRegrouping)
         {
         }
 

--- a/Oracle.NoSQL.SDK/src/Query/ValueAggregators.cs
+++ b/Oracle.NoSQL.SDK/src/Query/ValueAggregators.cs
@@ -257,6 +257,34 @@ namespace Oracle.NoSQL.SDK.Query
         {
         }
 
+        // The proxy always sends array_collect_distinct partial results as
+        // arrays. Unlike ordinary array_collect, this is independent of the
+        // regrouping flag (matching GroupIter in the Java driver).
+        internal override long Aggregate(FieldValue value, bool countMemory)
+        {
+            if (value == FieldValue.Null || value == FieldValue.Empty)
+            {
+                return 0;
+            }
+
+            if (!(value is ArrayValue array))
+            {
+                throw new InvalidOperationException(
+                    "Query: input value for array_collect_distinct is not an ArrayValue");
+            }
+
+            long memory = 0;
+            foreach (var element in array)
+            {
+                AddValue(element);
+                if (countMemory)
+                {
+                    memory += GetMemorySize(element.GetMemorySize());
+                }
+            }
+            return memory;
+        }
+
         internal override FieldValue Result
         {
             get

--- a/Oracle.NoSQL.SDK/src/Query/VirtualScan.cs
+++ b/Oracle.NoSQL.SDK/src/Query/VirtualScan.cs
@@ -9,27 +9,94 @@ namespace Oracle.NoSQL.SDK.Query
 {
     internal class VirtualScan
     {
+        internal sealed class TableResumeInfo
+        {
+            internal int CurrentIndexRange { get; set; }
+
+            internal byte[] PrimaryKey { get; set; }
+
+            internal byte[] SecondaryKey { get; set; }
+
+            internal bool MoveAfterResumeKey { get; set; }
+
+            internal byte[] JoinDescendantResumeKey { get; set; }
+
+            internal int[] JoinPathTableIds { get; set; }
+
+            internal byte[] JoinPathPrimaryKey { get; set; }
+
+            internal byte[] JoinPathSecondaryKey { get; set; }
+
+            internal bool JoinPathMatched { get; set; }
+        }
+
+        private TableResumeInfo[] tableResumeInfos =
+            { new TableResumeInfo() };
+
         internal int ShardId { get; set; }
 
         internal int PartitionId { get; set; }
 
-        internal byte[] PrimaryKey { get; set; }
+        internal TableResumeInfo[] TableResumeInfos
+        {
+            get => tableResumeInfos;
+            set => tableResumeInfos = value;
+        }
 
-        internal byte[] SecondaryKey { get; set; }
+        private TableResumeInfo FirstTableResumeInfo =>
+            tableResumeInfos != null && tableResumeInfos.Length != 0
+                ? tableResumeInfos[0] : null;
 
-        internal byte[] JoinDescendantResumeKey { get; set; }
+        // V4 compatibility accessors for the single-table virtual-scan form.
+        internal byte[] PrimaryKey
+        {
+            get => FirstTableResumeInfo?.PrimaryKey;
+            set => FirstTableResumeInfo.PrimaryKey = value;
+        }
 
-        internal int[] JoinPathTableIds { get; set; }
+        internal byte[] SecondaryKey
+        {
+            get => FirstTableResumeInfo?.SecondaryKey;
+            set => FirstTableResumeInfo.SecondaryKey = value;
+        }
 
-        internal byte[] JoinPathPrimaryKey { get; set; }
+        internal byte[] JoinDescendantResumeKey
+        {
+            get => FirstTableResumeInfo?.JoinDescendantResumeKey;
+            set => FirstTableResumeInfo.JoinDescendantResumeKey = value;
+        }
 
-        internal byte[] JoinPathSecondaryKey { get; set; }
+        internal int[] JoinPathTableIds
+        {
+            get => FirstTableResumeInfo?.JoinPathTableIds;
+            set => FirstTableResumeInfo.JoinPathTableIds = value;
+        }
+
+        internal byte[] JoinPathPrimaryKey
+        {
+            get => FirstTableResumeInfo?.JoinPathPrimaryKey;
+            set => FirstTableResumeInfo.JoinPathPrimaryKey = value;
+        }
+
+        internal byte[] JoinPathSecondaryKey
+        {
+            get => FirstTableResumeInfo?.JoinPathSecondaryKey;
+            set => FirstTableResumeInfo.JoinPathSecondaryKey = value;
+        }
 
         internal bool IsInfoSent { get; set; }
         
-        internal bool MoveAfterResumeKey { get; set; }
+        internal bool MoveAfterResumeKey
+        {
+            get => FirstTableResumeInfo?.MoveAfterResumeKey ?? false;
+            set => FirstTableResumeInfo.MoveAfterResumeKey = value;
+        }
 
-        internal bool JoinPathMatched { get; set; }
+        internal bool JoinPathMatched
+        {
+            get => FirstTableResumeInfo?.JoinPathMatched ?? false;
+            set => FirstTableResumeInfo.JoinPathMatched = value;
+        }
 
     }
 

--- a/Oracle.NoSQL.SDK/src/Request/PrepareRequest.cs
+++ b/Oracle.NoSQL.SDK/src/Request/PrepareRequest.cs
@@ -19,7 +19,9 @@ namespace Oracle.NoSQL.SDK
     {
         internal const short QueryV3 = 3;
         internal const short QueryV4 = 4;
-        internal const short DefaultQueryVersion = QueryV4;
+        internal const short QueryV5 = 5;
+        internal const short QueryV6 = 6;
+        internal const short DefaultQueryVersion = QueryV6;
 
         internal QueryRequestBase(NoSQLClient client) : base(client)
         {

--- a/Oracle.NoSQL.SDK/src/Request/QueryRequest.cs
+++ b/Oracle.NoSQL.SDK/src/Request/QueryRequest.cs
@@ -120,6 +120,13 @@ namespace Oracle.NoSQL.SDK
         internal override string InternalTableName =>
             PreparedStatement?.GetTableName(UnionBranch);
 
+        // A V6 UNION plan has one proxy statement per branch. The proxy must
+        // receive the namespace paired with the selected branch, matching the
+        // Java driver's QueryRequest.getNamespace() behavior.
+        internal override string Namespace => PreparedStatement != null
+            ? PreparedStatement.GetNamespace(UnionBranch)
+            : base.Namespace;
+
         internal QueryContinuationKey ContinuationKey =>
             Options?.ContinuationKey;
 

--- a/Oracle.NoSQL.SDK/src/Request/QueryRequest.cs
+++ b/Oracle.NoSQL.SDK/src/Request/QueryRequest.cs
@@ -77,6 +77,10 @@ namespace Oracle.NoSQL.SDK
         // feature preflight without counting each internal fetch as a new query.
         internal QueryRequest StatsLogicalQueryRequest { get; set; }
 
+        // The proxy prepared statement to use for the current UNION branch.
+        // It is set by the driver plan only for internal fetch requests.
+        internal int UnionBranch { get; set; }
+
         internal void DeferStatsLogicalQuery()
         {
             Interlocked.Exchange(ref statsLogicalQueryPending, 1);
@@ -114,7 +118,7 @@ namespace Oracle.NoSQL.SDK
             PreparedStatement.OperationCode == OperationCodeSelect;
 
         internal override string InternalTableName =>
-            PreparedStatement?.TableName;
+            PreparedStatement?.GetTableName(UnionBranch);
 
         internal QueryContinuationKey ContinuationKey =>
             Options?.ContinuationKey;

--- a/Oracle.NoSQL.SDK/src/Request/QueryRequest.cs
+++ b/Oracle.NoSQL.SDK/src/Request/QueryRequest.cs
@@ -8,6 +8,7 @@
 namespace Oracle.NoSQL.SDK
 {
     using System;
+    using System.Collections.Generic;
     using System.Diagnostics;
     using System.IO;
     using System.Threading;
@@ -68,6 +69,13 @@ namespace Oracle.NoSQL.SDK
 
         internal TopologyInfo BaseTopology { get; set; }
 
+        // Advanced query execution captures topology snapshots when its
+        // runtime is created. Internal fetches must advertise that same view.
+        internal IReadOnlyList<TopologyInfo> StoreTopologySnapshot { get; set; }
+
+        internal override IReadOnlyList<TopologyInfo> StoreTopologies =>
+            StoreTopologySnapshot ?? base.StoreTopologies;
+
         internal VirtualScan VirtualScan { get; set; }
 
         internal bool IsInternal { get; set; }
@@ -120,12 +128,10 @@ namespace Oracle.NoSQL.SDK
         internal override string InternalTableName =>
             PreparedStatement?.GetTableName(UnionBranch);
 
-        // A V6 UNION plan has one proxy statement per branch. The proxy must
-        // receive the namespace paired with the selected branch, matching the
-        // Java driver's QueryRequest.getNamespace() behavior.
-        internal override string Namespace => PreparedStatement != null
-            ? PreparedStatement.GetNamespace(UnionBranch)
-            : base.Namespace;
+        // An explicit request or configured namespace takes precedence. If
+        // neither is present, a V6 UNION request uses its branch namespace.
+        internal override string Namespace => base.Namespace ??
+            PreparedStatement?.GetNamespace(UnionBranch);
 
         internal QueryContinuationKey ContinuationKey =>
             Options?.ContinuationKey;

--- a/Oracle.NoSQL.SDK/src/Request/Request.cs
+++ b/Oracle.NoSQL.SDK/src/Request/Request.cs
@@ -112,7 +112,7 @@ namespace Oracle.NoSQL.SDK
         internal string Compartment =>
             BaseOptions?.Compartment ?? Config.Compartment;
 
-        internal string Namespace =>
+        internal virtual string Namespace =>
             BaseOptions?.Namespace ?? Config.Namespace;
 
         internal int RequestTimeoutMillis { get; set; }

--- a/Oracle.NoSQL.SDK/src/Request/Request.cs
+++ b/Oracle.NoSQL.SDK/src/Request/Request.cs
@@ -115,6 +115,9 @@ namespace Oracle.NoSQL.SDK
         internal virtual string Namespace =>
             BaseOptions?.Namespace ?? Config.Namespace;
 
+        internal virtual IReadOnlyList<TopologyInfo> StoreTopologies =>
+            Client.StoreTopologies;
+
         internal int RequestTimeoutMillis { get; set; }
 
         internal TimeSpan Timeout

--- a/Oracle.NoSQL.SDK/src/Result/PreparedStatement.cs
+++ b/Oracle.NoSQL.SDK/src/Result/PreparedStatement.cs
@@ -307,7 +307,70 @@ namespace Oracle.NoSQL.SDK
         /// </remarks>
         public void ClearVariables() => Variables.Clear();
 
-        internal byte[] ProxyStatement { get; set; }
+        internal sealed class QueryBranch
+        {
+            internal byte[] ProxyStatement { get; set; }
+
+            internal string Namespace { get; set; }
+
+            internal string TableName { get; set; }
+        }
+
+        private readonly List<QueryBranch> queryBranches =
+            new List<QueryBranch>();
+
+        internal IReadOnlyList<QueryBranch> QueryBranches => queryBranches;
+
+        internal byte[] ProxyStatement
+        {
+            get => queryBranches.Count == 0 ? null :
+                queryBranches[0].ProxyStatement;
+            set => GetOrCreateQueryBranch(0).ProxyStatement = value;
+        }
+
+        internal byte[] GetProxyStatement(int branch) =>
+            GetQueryBranch(branch).ProxyStatement;
+
+        internal string GetNamespace(int branch) =>
+            branch >= 0 && branch < queryBranches.Count ?
+                queryBranches[branch].Namespace : null;
+
+        internal string GetTableName(int branch) =>
+            branch >= 0 && branch < queryBranches.Count ?
+                queryBranches[branch].TableName : null;
+
+        internal void AddQueryBranch(QueryBranch branch)
+        {
+            if (branch == null || branch.ProxyStatement == null)
+            {
+                throw new BadProtocolException(
+                    "Query: missing proxy prepared statement in query branch");
+            }
+
+            queryBranches.Add(branch);
+        }
+
+        private QueryBranch GetOrCreateQueryBranch(int branch)
+        {
+            while (queryBranches.Count <= branch)
+            {
+                queryBranches.Add(new QueryBranch());
+            }
+
+            return queryBranches[branch];
+        }
+
+        private QueryBranch GetQueryBranch(int branch)
+        {
+            if (branch < 0 || branch >= queryBranches.Count ||
+                queryBranches[branch].ProxyStatement == null)
+            {
+                throw new BadProtocolException(
+                    $"Query: invalid UNION branch {branch}");
+            }
+
+            return queryBranches[branch];
+        }
 
         internal PlanStep DriverQueryPlan { get; set; }
 
@@ -321,9 +384,17 @@ namespace Oracle.NoSQL.SDK
         // prepared statement (ProxyStatement) that is normally opaque.  They
         // are currently used for rate limiting.
 
-        internal string Namespace { get; set; }
+        internal string Namespace
+        {
+            get => queryBranches.Count == 0 ? null : queryBranches[0].Namespace;
+            set => GetOrCreateQueryBranch(0).Namespace = value;
+        }
 
-        internal string TableName { get; set; }
+        internal string TableName
+        {
+            get => queryBranches.Count == 0 ? null : queryBranches[0].TableName;
+            set => GetOrCreateQueryBranch(0).TableName = value;
+        }
 
         internal sbyte OperationCode { get; set; }
 

--- a/Oracle.NoSQL.SDK/src/Result/PreparedStatement.cs
+++ b/Oracle.NoSQL.SDK/src/Result/PreparedStatement.cs
@@ -14,12 +14,16 @@ namespace Oracle.NoSQL.SDK
 
     internal class TopologyInfo
     {
+        internal string StoreName { get; }
+
         internal int SequenceNumber { get; }
 
         internal IReadOnlyList<int> ShardIds { get; }
 
-        internal TopologyInfo(int sequenceNumber, IReadOnlyList<int> shardIds)
+        internal TopologyInfo(int sequenceNumber, IReadOnlyList<int> shardIds,
+            string storeName = null)
         {
+            StoreName = storeName;
             SequenceNumber = sequenceNumber;
             ShardIds = shardIds;
         }
@@ -314,6 +318,8 @@ namespace Oracle.NoSQL.SDK
             internal string Namespace { get; set; }
 
             internal string TableName { get; set; }
+
+            internal string StoreName { get; set; }
         }
 
         private readonly List<QueryBranch> queryBranches =
@@ -338,6 +344,27 @@ namespace Oracle.NoSQL.SDK
         internal string GetTableName(int branch) =>
             branch >= 0 && branch < queryBranches.Count ?
                 queryBranches[branch].TableName : null;
+
+        internal string GetStoreName(int branch) =>
+            branch >= 0 && branch < queryBranches.Count ?
+                queryBranches[branch].StoreName : null;
+
+        internal void SetQueryBranchStores(IReadOnlyList<string> storeNames)
+        {
+            if (storeNames == null)
+            {
+                return;
+            }
+            if (storeNames.Count != queryBranches.Count)
+            {
+                throw new BadProtocolException(
+                    "Query: number of branch store names does not match the number of query branches");
+            }
+            for (var i = 0; i < storeNames.Count; i++)
+            {
+                queryBranches[i].StoreName = storeNames[i];
+            }
+        }
 
         internal void AddQueryBranch(QueryBranch branch)
         {

--- a/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/NamespaceTests.cs
+++ b/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/NamespaceTests.cs
@@ -171,6 +171,31 @@ namespace Oracle.NoSQL.SDK.Tests
             Assert.IsTrue(result.Success);
         }
 
+        [TestMethod]
+        public async Task TestUnionQueryUsesBranchNamespaceAsync()
+        {
+            await PutRowAsync(Fixture.Table, GoodRow);
+
+            var select = $"SELECT * FROM {FullTableName}";
+            var statement = await invalidNsClient.PrepareAsync(
+                select + " UNION ALL " + select);
+            var options = new QueryOptions
+            {
+                Limit = 1
+            };
+            var rowCount = 0;
+
+            do
+            {
+                var result = await invalidNsClient.QueryAsync(statement,
+                    options);
+                rowCount += result.Rows.Count;
+                options.ContinuationKey = result.ContinuationKey;
+            } while (options.ContinuationKey != null);
+
+            Assert.AreEqual(2, rowCount);
+        }
+
         // We will shorten the rest of DML tests to only focus on options
 
         [TestMethod]

--- a/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/QueryTests.Positive.cs
+++ b/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/QueryTests.Positive.cs
@@ -492,11 +492,22 @@ namespace Oracle.NoSQL.SDK.Tests
         {
             CheckOnPrem();
 
-            var select = $"SELECT shardId, pkString FROM {Fixture.Table.Name}";
-            var sql = select + " UNION ALL " + select;
+            var select = sorted
+                ? $"SELECT shardId, pkString FROM {Fixture.Table.Name}"
+                : $"SELECT 1 AS branch, shardId, pkString FROM " +
+                  Fixture.Table.Name;
+            var secondSelect = sorted
+                ? select
+                : $"SELECT 2 AS branch, shardId, pkString FROM " +
+                  Fixture.Table.Name;
+            var union = select + " UNION ALL " + secondSelect;
+            var sql = union;
             if (sorted)
             {
-                sql += " ORDER BY shardId, pkString";
+                // ORDER BY belongs to a UNION branch. Wrap the UNION in an
+                // outer query to order the combined result.
+                sql = "SELECT $u.shardId, $u.pkString FROM (" + union +
+                    ") AS $u ORDER BY $u.shardId, $u.pkString";
             }
 
             var statement = await client.PrepareAsync(sql);
@@ -506,19 +517,47 @@ namespace Oracle.NoSQL.SDK.Tests
                 // exercises UNION branch switching and continuation state.
                 Limit = 1
             };
-            var rowCount = 0;
+            var rows = new List<RecordValue>();
             var queryCallCount = 0;
 
             do
             {
                 var result = await client.QueryAsync(statement, options);
-                rowCount += result.Rows.Count;
+                rows.AddRange(result.Rows);
                 queryCallCount++;
                 options.ContinuationKey = result.ContinuationKey;
             } while (options.ContinuationKey != null);
 
-            Assert.AreEqual(Fixture.Rows.Count() * 2, rowCount);
+            Assert.AreEqual(Fixture.Rows.Count() * 2, rows.Count);
             Assert.IsTrue(queryCallCount > 1);
+
+            if (!sorted)
+            {
+                // UNION ALL without ORDER BY must drain branch 1 before
+                // advancing to branch 2, even when every row has a separate
+                // continuation key.
+                var branchBoundary = Fixture.Rows.Count();
+                for (var i = 0; i < rows.Count; i++)
+                {
+                    Assert.AreEqual(i < branchBoundary ? 1 : 2,
+                        rows[i]["branch"].AsInt32);
+                }
+                return;
+            }
+
+            // A sorted UNION must maintain its order across continuation
+            // keys, including equal rows supplied by the two branches.
+            for (var i = 1; i < rows.Count; i++)
+            {
+                var previous = rows[i - 1];
+                var current = rows[i];
+                var shardComparison = previous["shardId"].AsInt32.CompareTo(
+                    current["shardId"].AsInt32);
+                Assert.IsTrue(shardComparison < 0 ||
+                    shardComparison == 0 && string.CompareOrdinal(
+                        previous["pkString"].AsString,
+                        current["pkString"].AsString) <= 0);
+            }
         }
 
         [DataTestMethod]

--- a/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/QueryTests.Positive.cs
+++ b/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/QueryTests.Positive.cs
@@ -475,6 +475,52 @@ namespace Oracle.NoSQL.SDK.Tests
             } while (options.ContinuationKey != null);
         }
 
+        [TestMethod]
+        public async Task TestUnionAllSequentialContinuationAsync()
+        {
+            await VerifyUnionAllContinuationAsync(false);
+        }
+
+        [TestMethod]
+        public async Task TestUnionAllSortedContinuationAsync()
+        {
+            await VerifyUnionAllContinuationAsync(true);
+        }
+
+        private static async Task VerifyUnionAllContinuationAsync(
+            bool sorted)
+        {
+            CheckOnPrem();
+
+            var select = $"SELECT shardId, pkString FROM {Fixture.Table.Name}";
+            var sql = select + " UNION ALL " + select;
+            if (sorted)
+            {
+                sql += " ORDER BY shardId, pkString";
+            }
+
+            var statement = await client.PrepareAsync(sql);
+            var options = new QueryOptions
+            {
+                // Each call can issue only one proxy fetch. A one-row limit
+                // exercises UNION branch switching and continuation state.
+                Limit = 1
+            };
+            var rowCount = 0;
+            var queryCallCount = 0;
+
+            do
+            {
+                var result = await client.QueryAsync(statement, options);
+                rowCount += result.Rows.Count;
+                queryCallCount++;
+                options.ContinuationKey = result.ContinuationKey;
+            } while (options.ContinuationKey != null);
+
+            Assert.AreEqual(Fixture.Rows.Count() * 2, rowCount);
+            Assert.IsTrue(queryCallCount > 1);
+        }
+
         [DataTestMethod]
         [DynamicData(nameof(PreparedQueryDataSource))]
         public async Task TestPreparedQueryAsyncEnumerableAsync(QTest test,

--- a/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/QueryTests.Positive.cs
+++ b/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/QueryTests.Positive.cs
@@ -487,6 +487,27 @@ namespace Oracle.NoSQL.SDK.Tests
             await VerifyUnionAllContinuationAsync(true);
         }
 
+        [TestMethod]
+        public async Task TestUnionAllCaseExpressionAsync()
+        {
+            CheckOnPrem();
+            var source = $"SELECT colInteger FROM {Fixture.Table.Name}";
+            var sql = "SELECT CASE WHEN $u.colInteger > 10 THEN " +
+                "$u.colInteger ELSE 0 END AS value FROM (" + source +
+                " UNION ALL " + source + ") $u";
+            var statement = await client.PrepareAsync(sql);
+            var rows = new List<RecordValue>();
+
+            await foreach (var result in client.GetQueryAsyncEnumerable(
+                statement))
+            {
+                rows.AddRange(result.Rows);
+            }
+
+            Assert.AreEqual(Fixture.Rows.Count() * 2, rows.Count);
+            Assert.IsTrue(rows.All(row => row["value"].IsNumeric));
+        }
+
         private static async Task VerifyUnionAllContinuationAsync(
             bool sorted)
         {

--- a/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/QueryV6CompatibilityTests.cs
+++ b/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/QueryV6CompatibilityTests.cs
@@ -44,6 +44,39 @@ namespace Oracle.NoSQL.SDK.Tests
         }
 
         [TestMethod]
+        public void TestUnionBranchNamespaceOverridesQueryOptions()
+        {
+            var statement = new PreparedStatement();
+            statement.AddQueryBranch(new PreparedStatement.QueryBranch
+            {
+                ProxyStatement = new byte[] { 1 },
+                Namespace = "firstNamespace"
+            });
+            statement.AddQueryBranch(new PreparedStatement.QueryBranch
+            {
+                ProxyStatement = new byte[] { 2 },
+                Namespace = "secondNamespace"
+            });
+
+            using var client = new NoSQLClient(new NoSQLConfig
+            {
+                ServiceType = ServiceType.CloudSim,
+                Endpoint = "http://localhost:8080",
+                Namespace = "configNamespace"
+            });
+            var request = new QueryRequest<RecordValue>(client, statement,
+                new QueryOptions
+                {
+                    Namespace = "optionsNamespace"
+                });
+
+            request.UnionBranch = 0;
+            Assert.AreEqual("firstNamespace", request.Namespace);
+            request.UnionBranch = 1;
+            Assert.AreEqual("secondNamespace", request.Namespace);
+        }
+
+        [TestMethod]
         public void TestQueryVersionFallbackFromV6ToV3()
         {
             var handler = new ProtocolHandler();

--- a/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/QueryV6CompatibilityTests.cs
+++ b/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/QueryV6CompatibilityTests.cs
@@ -1,0 +1,83 @@
+/*-
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ * https://oss.oracle.com/licenses/upl/
+ */
+
+namespace Oracle.NoSQL.SDK.Tests
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Oracle.NoSQL.SDK.Query;
+
+    [TestClass]
+    public class QueryV6CompatibilityTests
+    {
+        [TestMethod]
+        public void TestPreparedStatementUsesEachUnionBranch()
+        {
+            var statement = new PreparedStatement();
+            var firstProxy = new byte[] { 1 };
+            var secondProxy = new byte[] { 2 };
+
+            statement.AddQueryBranch(new PreparedStatement.QueryBranch
+            {
+                ProxyStatement = firstProxy,
+                Namespace = "firstNamespace",
+                TableName = "firstTable"
+            });
+            statement.AddQueryBranch(new PreparedStatement.QueryBranch
+            {
+                ProxyStatement = secondProxy,
+                Namespace = "secondNamespace",
+                TableName = "secondTable"
+            });
+
+            CollectionAssert.AreEqual(firstProxy,
+                statement.GetProxyStatement(0));
+            CollectionAssert.AreEqual(secondProxy,
+                statement.GetProxyStatement(1));
+            Assert.AreEqual("firstNamespace", statement.GetNamespace(0));
+            Assert.AreEqual("secondTable", statement.GetTableName(1));
+            Assert.ThrowsException<BadProtocolException>(() =>
+                statement.GetProxyStatement(2));
+        }
+
+        [TestMethod]
+        public void TestQueryVersionFallbackFromV6ToV3()
+        {
+            var handler = new ProtocolHandler();
+
+            Assert.AreEqual(QueryRequestBase.QueryV6, handler.QueryVersion);
+            Assert.IsTrue(handler.DecrementQueryVersion(
+                QueryRequestBase.QueryV6));
+            Assert.AreEqual(QueryRequestBase.QueryV5, handler.QueryVersion);
+            Assert.IsTrue(handler.DecrementQueryVersion(
+                QueryRequestBase.QueryV5));
+            Assert.AreEqual(QueryRequestBase.QueryV4, handler.QueryVersion);
+            Assert.IsTrue(handler.DecrementQueryVersion(
+                QueryRequestBase.QueryV4));
+            Assert.AreEqual(QueryRequestBase.QueryV3, handler.QueryVersion);
+            Assert.IsFalse(handler.DecrementQueryVersion(
+                QueryRequestBase.QueryV3));
+        }
+
+        [TestMethod]
+        public void TestArrayCollectRegrouping()
+        {
+            var normal = new CollectAggregator(false, false);
+            normal.Aggregate(new StringValue("one"));
+            Assert.AreEqual(1, normal.Result.AsArrayValue.Count);
+            Assert.AreEqual("one", normal.Result.AsArrayValue[0].AsString);
+
+            var regrouped = new CollectAggregator(false, true);
+            regrouped.Aggregate(new ArrayValue
+            {
+                new StringValue("one"), new StringValue("two")
+            });
+            Assert.AreEqual(2, regrouped.Result.AsArrayValue.Count);
+            Assert.AreEqual("one", regrouped.Result.AsArrayValue[0].AsString);
+            Assert.AreEqual("two", regrouped.Result.AsArrayValue[1].AsString);
+        }
+    }
+}

--- a/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/QueryV6CompatibilityTests.cs
+++ b/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/QueryV6CompatibilityTests.cs
@@ -12,6 +12,8 @@ namespace Oracle.NoSQL.SDK.Tests
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Oracle.NoSQL.SDK.Query;
     using BinaryProtocol = Oracle.NoSQL.SDK.BinaryProtocol.Protocol;
+    using NsonProtocol = Oracle.NoSQL.SDK.NsonProtocol.Protocol;
+    using Opcode = Oracle.NoSQL.SDK.BinaryProtocol.Opcode;
     using PlanSerializer = Oracle.NoSQL.SDK.Query.BinaryProtocol.PlanSerializer;
 
     [TestClass]
@@ -53,7 +55,7 @@ namespace Oracle.NoSQL.SDK.Tests
         }
 
         [TestMethod]
-        public void TestUnionBranchNamespaceOverridesQueryOptions()
+        public void TestPreparedQueryNamespacePrecedence()
         {
             var statement = new PreparedStatement();
             statement.AddQueryBranch(new PreparedStatement.QueryBranch
@@ -80,9 +82,22 @@ namespace Oracle.NoSQL.SDK.Tests
                 });
 
             request.UnionBranch = 0;
-            Assert.AreEqual("firstNamespace", request.Namespace);
+            Assert.AreEqual("optionsNamespace", request.Namespace);
             request.UnionBranch = 1;
-            Assert.AreEqual("secondNamespace", request.Namespace);
+            Assert.AreEqual("optionsNamespace", request.Namespace);
+
+            request.Options = null;
+            Assert.AreEqual("configNamespace", request.Namespace);
+
+            using var noDefaultClient = new NoSQLClient(new NoSQLConfig
+            {
+                ServiceType = ServiceType.CloudSim,
+                Endpoint = "http://localhost:8080"
+            });
+            var branchRequest = new QueryRequest<RecordValue>(
+                noDefaultClient, statement, null);
+            branchRequest.UnionBranch = 1;
+            Assert.AreEqual("secondNamespace", branchRequest.Namespace);
         }
 
         [TestMethod]
@@ -130,6 +145,27 @@ namespace Oracle.NoSQL.SDK.Tests
             Assert.AreEqual(2, distinct.Result.AsArrayValue.Count);
             Assert.AreEqual(1, distinct.Result.AsArrayValue[0].AsInt32);
             Assert.AreEqual(2, distinct.Result.AsArrayValue[1].AsInt32);
+        }
+
+        [TestMethod]
+        public void TestPreV6GroupPlanDefaultsToRegrouping()
+        {
+            using var stream = new MemoryStream();
+            BinaryProtocol.WriteByte(stream, 65); // GROUP
+            WriteBase(stream);
+            WriteIntegerConstStep(stream);
+            BinaryProtocol.WriteUnpackedInt32(stream, 0);
+            WriteStringArray(stream, "values");
+            BinaryProtocol.WriteUnpackedInt16(stream,
+                (short)SQLFuncCode.ArrayCollect);
+            BinaryProtocol.WriteBoolean(stream, false);
+            BinaryProtocol.WriteBoolean(stream, false);
+            BinaryProtocol.WriteBoolean(stream, false);
+            stream.Position = 0;
+
+            var step = (GroupStep)PlanSerializer.DeserializeStep(stream,
+                QueryRequestBase.QueryV5);
+            Assert.IsTrue(step.IsRegrouping);
         }
 
         [TestMethod]
@@ -360,6 +396,54 @@ namespace Oracle.NoSQL.SDK.Tests
             Assert.AreEqual(4, runtime.GetConstructionTopology().SequenceNumber);
             runtime.ConstructionUnionBranch = 1;
             Assert.AreEqual(7, runtime.GetConstructionTopology().SequenceNumber);
+
+            client.SetQueryTopology(new TopologyInfo(8, new[] { 4 },
+                "storeOne"));
+            client.SetQueryTopology(new TopologyInfo(10, new[] { 5, 6 },
+                "storeTwo"));
+
+            Assert.AreEqual(4, runtime.StoreTopologies[0].SequenceNumber);
+            Assert.AreEqual(7, runtime.StoreTopologies[1].SequenceNumber);
+
+            var request = new QueryRequest<RecordValue>(client, statement,
+                null)
+            {
+                StoreTopologySnapshot = runtime.StoreTopologies
+            };
+            using var stream = new MemoryStream();
+            var writer = NsonProtocol.GetNsonWriter(stream);
+            writer.StartMap();
+            NsonProtocol.WriteHeader(writer, Opcode.Query, request);
+            writer.EndMap();
+            stream.Position = 0;
+            var reader = NsonProtocol.GetNsonReader(stream);
+            reader.Next();
+            var root = NsonProtocol.ReadFieldValue(reader).AsMapValue;
+            var header = root[NsonProtocol.FieldNames.Header].AsMapValue;
+            var storeTopologies = header[NsonProtocol.FieldNames
+                .StoreTopologySequenceNumbers].AsArrayValue;
+            Assert.AreEqual(4, GetTopologySequence(storeTopologies,
+                "storeOne"));
+            Assert.AreEqual(7, GetTopologySequence(storeTopologies,
+                "storeTwo"));
+        }
+
+        private static int GetTopologySequence(ArrayValue storeTopologies,
+            string storeName)
+        {
+            foreach (var fieldValue in storeTopologies)
+            {
+                var topology = fieldValue.AsMapValue;
+                if (topology[NsonProtocol.FieldNames.StoreId].AsString ==
+                    storeName)
+                {
+                    return topology[NsonProtocol.FieldNames.TopoSeqNum]
+                        .AsInt32;
+                }
+            }
+
+            throw new AssertFailedException(
+                "Missing topology for store " + storeName);
         }
 
         private static ConstStep IntegerConstant(int position, int value) =>
@@ -388,6 +472,16 @@ namespace Oracle.NoSQL.SDK.Tests
             for (var i = 0; i < count; i++)
             {
                 writeStep(stream);
+            }
+        }
+
+        private static void WriteStringArray(MemoryStream stream,
+            params string[] values)
+        {
+            BinaryProtocol.WritePackedInt32(stream, values.Length);
+            foreach (var value in values)
+            {
+                BinaryProtocol.WriteString(stream, value);
             }
         }
 

--- a/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/QueryV6CompatibilityTests.cs
+++ b/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/QueryV6CompatibilityTests.cs
@@ -7,8 +7,12 @@
 
 namespace Oracle.NoSQL.SDK.Tests
 {
+    using System;
+    using System.IO;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Oracle.NoSQL.SDK.Query;
+    using BinaryProtocol = Oracle.NoSQL.SDK.BinaryProtocol.Protocol;
+    using PlanSerializer = Oracle.NoSQL.SDK.Query.BinaryProtocol.PlanSerializer;
 
     [TestClass]
     public class QueryV6CompatibilityTests
@@ -39,6 +43,11 @@ namespace Oracle.NoSQL.SDK.Tests
                 statement.GetProxyStatement(1));
             Assert.AreEqual("firstNamespace", statement.GetNamespace(0));
             Assert.AreEqual("secondTable", statement.GetTableName(1));
+            statement.SetQueryBranchStores(new[] { "storeOne", "storeTwo" });
+            Assert.AreEqual("storeOne", statement.GetStoreName(0));
+            Assert.AreEqual("storeTwo", statement.GetStoreName(1));
+            Assert.ThrowsException<BadProtocolException>(() =>
+                statement.SetQueryBranchStores(new[] { "onlyOne" }));
             Assert.ThrowsException<BadProtocolException>(() =>
                 statement.GetProxyStatement(2));
         }
@@ -111,6 +120,299 @@ namespace Oracle.NoSQL.SDK.Tests
             Assert.AreEqual(2, regrouped.Result.AsArrayValue.Count);
             Assert.AreEqual("one", regrouped.Result.AsArrayValue[0].AsString);
             Assert.AreEqual("two", regrouped.Result.AsArrayValue[1].AsString);
+
+            var distinct = new CollectDistinctAggregator(false, false);
+            distinct.Aggregate(new ArrayValue
+            {
+                new IntegerValue(1), new IntegerValue(2),
+                new IntegerValue(1)
+            });
+            Assert.AreEqual(2, distinct.Result.AsArrayValue.Count);
+            Assert.AreEqual(1, distinct.Result.AsArrayValue[0].AsInt32);
+            Assert.AreEqual(2, distinct.Result.AsArrayValue[1].AsInt32);
+        }
+
+        [TestMethod]
+        public void TestV6DriverOperatorDeserialization()
+        {
+            Assert.IsInstanceOfType(DeserializeV6Step(3, stream =>
+            {
+                BinaryProtocol.WriteBoolean(stream, false);
+                WriteStepArray(stream, 1, WriteIntegerConstStep);
+            }), typeof(ArrayConstructorStep));
+
+            Assert.IsInstanceOfType(DeserializeV6Step(3, stream =>
+            {
+                BinaryProtocol.WriteBoolean(stream, false);
+                WriteStepArray(stream, 0, WriteIntegerConstStep);
+            }), typeof(ArrayConstructorStep));
+
+            Assert.IsInstanceOfType(DeserializeV6Step(5, stream =>
+            {
+                BinaryProtocol.WriteUnpackedInt16(stream,
+                    (short)QueryFuncCode.Equal);
+                WriteIntegerConstStep(stream);
+                WriteIntegerConstStep(stream);
+            }), typeof(ValueCompareStep));
+
+            Assert.IsInstanceOfType(DeserializeV6Step(7, stream =>
+            {
+                BinaryProtocol.WriteUnpackedInt16(stream,
+                    (short)QueryFuncCode.And);
+                WriteStepArray(stream, 1, WriteBooleanConstStep);
+            }), typeof(AndOrStep));
+
+            Assert.IsInstanceOfType(DeserializeV6Step(19, stream =>
+            {
+                WriteStepArray(stream, 1, WriteBooleanConstStep);
+                WriteStepArray(stream, 1, WriteIntegerConstStep);
+                WriteIntegerConstStep(stream);
+            }), typeof(CaseStep));
+
+            Assert.IsInstanceOfType(DeserializeV6Step(26, stream =>
+            {
+                BinaryProtocol.WriteUnpackedInt16(stream,
+                    (short)QueryFuncCode.IsNull);
+                WriteIntegerConstStep(stream);
+            }), typeof(IsNullStep));
+
+            Assert.IsInstanceOfType(DeserializeV6Step(48, stream =>
+            {
+                BinaryProtocol.WriteUnpackedInt16(stream,
+                    (short)QueryFuncCode.SeqSum);
+                WriteIntegerConstStep(stream);
+            }), typeof(SeqAggregateStep));
+        }
+
+        [TestMethod]
+        public void TestV6DriverOperatorsExecute()
+        {
+            using var client = new NoSQLClient(new NoSQLConfig
+            {
+                ServiceType = ServiceType.CloudSim,
+                Endpoint = "http://localhost:8080"
+            });
+            var runtime = new QueryRuntime(client, new PreparedStatement
+            {
+                RegisterCount = 16,
+                DriverQueryPlan = new ReceiveStep()
+            });
+            var comparison = new ValueCompareStep
+            {
+                ResultPosition = 0,
+                FuncCode = QueryFuncCode.GreaterThan,
+                LeftStep = IntegerConstant(1, 11),
+                RightStep = IntegerConstant(2, 10)
+            };
+            var @case = new CaseStep
+            {
+                ResultPosition = 3,
+                ConditionSteps = new PlanStep[] { comparison },
+                ThenSteps = new PlanStep[] { IntegerConstant(4, 11) },
+                ElseStep = IntegerConstant(5, 0)
+            };
+            var caseIterator = @case.CreateSyncIterator(runtime);
+            Assert.IsTrue(caseIterator.Next());
+            Assert.AreEqual(11, caseIterator.Result.AsInt32);
+
+            var arrayIterator = new ArrayConstructorStep
+            {
+                ResultPosition = 6,
+                ArgSteps = new PlanStep[] { IntegerConstant(7, 1) }
+            }.CreateSyncIterator(runtime);
+            Assert.IsTrue(arrayIterator.Next());
+            Assert.AreEqual(1, arrayIterator.Result.AsArrayValue.Count);
+
+            var emptyArrayIterator = new ArrayConstructorStep
+            {
+                ResultPosition = 8,
+                ArgSteps = Array.Empty<PlanStep>()
+            }.CreateSyncIterator(runtime);
+            Assert.IsTrue(emptyArrayIterator.Next());
+            Assert.AreEqual(0, emptyArrayIterator.Result.AsArrayValue.Count);
+
+            var aggregateIterator = new SeqAggregateStep
+            {
+                ResultPosition = 9,
+                FuncCode = QueryFuncCode.SeqSum,
+                InputStep = IntegerConstant(10, 3)
+            }.CreateSyncIterator(runtime);
+            Assert.IsTrue(aggregateIterator.Next());
+            Assert.AreEqual(DbType.Long, aggregateIterator.Result.DbType);
+            Assert.AreEqual(3L, aggregateIterator.Result.AsInt64);
+
+            var noInputIterator = new SeqAggregateStep
+            {
+                ResultPosition = 11,
+                FuncCode = QueryFuncCode.SeqSum,
+                InputStep = new FieldStep
+                {
+                    ResultPosition = 12,
+                    FieldName = "missing",
+                    InputStep = new ConstStep
+                    {
+                        ResultPosition = 13,
+                        Value = new MapValue()
+                    }
+                }
+            }.CreateSyncIterator(runtime);
+            Assert.IsFalse(noInputIterator.Next());
+        }
+
+        [TestMethod]
+        public void TestV6ComparisonAndAggregateMatchJavaSemantics()
+        {
+            using var client = new NoSQLClient(new NoSQLConfig
+            {
+                ServiceType = ServiceType.CloudSim,
+                Endpoint = "http://localhost:8080"
+            });
+            var runtime = new QueryRuntime(client, new PreparedStatement
+            {
+                RegisterCount = 8,
+                DriverQueryPlan = new ReceiveStep()
+            });
+
+            var nestedNullComparison = new ValueCompareStep
+            {
+                ResultPosition = 0,
+                FuncCode = QueryFuncCode.Equal,
+                LeftStep = new ConstStep
+                {
+                    ResultPosition = 1,
+                    Value = new ArrayValue { FieldValue.Null }
+                },
+                RightStep = new ConstStep
+                {
+                    ResultPosition = 2,
+                    Value = new ArrayValue { FieldValue.Null }
+                }
+            }.CreateSyncIterator(runtime);
+            Assert.IsTrue(nestedNullComparison.Next());
+            Assert.AreSame(FieldValue.Null, nestedNullComparison.Result);
+
+            var inputValue = new IntegerValue(3);
+            var sum = new SeqAggregateStep
+            {
+                ResultPosition = 3,
+                FuncCode = QueryFuncCode.SeqSum,
+                InputStep = new ConstStep
+                {
+                    ResultPosition = 4,
+                    Value = inputValue
+                }
+            }.CreateSyncIterator(runtime);
+            Assert.IsTrue(sum.Next());
+            Assert.AreEqual(DbType.Long, sum.Result.DbType);
+            Assert.AreEqual(3L, sum.Result.AsInt64);
+            Assert.AreEqual(3, inputValue.AsInt32);
+        }
+
+        [TestMethod]
+        public void TestV6PlanFormatterUsesJavaInputContainers()
+        {
+            var arrayPlan = PlanFormatter.Format(new ArrayConstructorStep
+            {
+                ResultPosition = 0,
+                ArgSteps = new PlanStep[] { IntegerConstant(1, 1) }
+            });
+            StringAssert.Contains(arrayPlan, "\"input iterators\" : [");
+
+            var comparisonPlan = PlanFormatter.Format(new ValueCompareStep
+            {
+                ResultPosition = 0,
+                FuncCode = QueryFuncCode.Equal,
+                LeftStep = IntegerConstant(1, 1),
+                RightStep = IntegerConstant(2, 1)
+            });
+            StringAssert.Contains(comparisonPlan, "\"input iterator\" :");
+        }
+
+        [TestMethod]
+        public void TestUnionRuntimeFreezesPerStoreTopology()
+        {
+            using var client = new NoSQLClient(new NoSQLConfig
+            {
+                ServiceType = ServiceType.CloudSim,
+                Endpoint = "http://localhost:8080"
+            });
+            client.SetQueryTopology(new TopologyInfo(4, new[] { 1 },
+                "storeOne"));
+            client.SetQueryTopology(new TopologyInfo(7, new[] { 2, 3 },
+                "storeTwo"));
+
+            var statement = new PreparedStatement
+            {
+                RegisterCount = 1,
+                DriverQueryPlan = new ReceiveStep()
+            };
+            statement.AddQueryBranch(new PreparedStatement.QueryBranch
+            {
+                ProxyStatement = new byte[] { 1 }, StoreName = "storeOne"
+            });
+            statement.AddQueryBranch(new PreparedStatement.QueryBranch
+            {
+                ProxyStatement = new byte[] { 2 }, StoreName = "storeTwo"
+            });
+            var runtime = new QueryRuntime(client, statement);
+
+            runtime.ConstructionUnionBranch = 0;
+            Assert.AreEqual(4, runtime.GetConstructionTopology().SequenceNumber);
+            runtime.ConstructionUnionBranch = 1;
+            Assert.AreEqual(7, runtime.GetConstructionTopology().SequenceNumber);
+        }
+
+        private static ConstStep IntegerConstant(int position, int value) =>
+            new ConstStep
+            {
+                ResultPosition = position,
+                Value = new IntegerValue(value)
+            };
+
+        private static PlanStep DeserializeV6Step(byte type,
+            Action<MemoryStream> writeContent)
+        {
+            using var stream = new MemoryStream();
+            BinaryProtocol.WriteByte(stream, type);
+            WriteBase(stream);
+            writeContent(stream);
+            stream.Position = 0;
+            return PlanSerializer.DeserializeStep(stream,
+                QueryRequestBase.QueryV6);
+        }
+
+        private static void WriteStepArray(MemoryStream stream, int count,
+            Action<MemoryStream> writeStep)
+        {
+            BinaryProtocol.WritePackedInt32(stream, count);
+            for (var i = 0; i < count; i++)
+            {
+                writeStep(stream);
+            }
+        }
+
+        private static void WriteIntegerConstStep(MemoryStream stream)
+        {
+            BinaryProtocol.WriteByte(stream, 0);
+            WriteBase(stream);
+            BinaryProtocol.WriteFieldValue(stream, new IntegerValue(1));
+        }
+
+        private static void WriteBooleanConstStep(MemoryStream stream)
+        {
+            BinaryProtocol.WriteByte(stream, 0);
+            WriteBase(stream);
+            BinaryProtocol.WriteFieldValue(stream, BooleanValue.True);
+        }
+
+        private static void WriteBase(MemoryStream stream)
+        {
+            BinaryProtocol.WriteUnpackedInt32(stream, 0);
+            BinaryProtocol.WriteUnpackedInt32(stream, 0);
+            for (var i = 0; i < 4; i++)
+            {
+                BinaryProtocol.WriteUnpackedInt32(stream, 0);
+            }
         }
     }
 }

--- a/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/RowMetadataValidationTests.cs
+++ b/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/RowMetadataValidationTests.cs
@@ -148,6 +148,10 @@ namespace Oracle.NoSQL.SDK.Tests
         {
             using var client = MakeClient();
             Assert.IsTrue(client.ProtocolHandler.DecrementQueryVersion(
+                QueryRequestBase.QueryV6));
+            Assert.IsTrue(client.ProtocolHandler.DecrementQueryVersion(
+                QueryRequestBase.QueryV5));
+            Assert.IsTrue(client.ProtocolHandler.DecrementQueryVersion(
                 QueryRequestBase.QueryV4));
             var request = new QueryRequest<RecordValue>(client,
                 "UPDATE users SET name = 'alice'",

--- a/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/StatsTests.cs
+++ b/Oracle.NoSQL.SDK/tests/Oracle.NoSQL.SDK.Tests/StatsTests.cs
@@ -990,6 +990,29 @@ namespace Oracle.NoSQL.SDK.Tests
         }
 
         [TestMethod]
+        public void TestPlanFormatterUsesJavaUnionBranchesAndSortSpecs()
+        {
+            var plan = Query.PlanFormatter.Format(new Query.UnionStep
+            {
+                ResultPosition = 4,
+                BranchSteps = new Query.PlanStep[]
+                {
+                    new Query.ReceiveStep { ResultPosition = 1 },
+                    new Query.ReceiveStep { ResultPosition = 2 }
+                },
+                SortSpecs = new[]
+                {
+                    new Query.SortSpec("id", true, false)
+                }
+            });
+
+            StringAssert.Contains(plan, "\"branches\" : [");
+            StringAssert.Contains(plan, "\"order by fields\" : [ id ]");
+            StringAssert.Contains(plan,
+                "\"sort specs\" : [ { \"desc\" : true, \"nulls_first\" : false } ]");
+        }
+
+        [TestMethod]
         public void TestDeferredLogicalQueryIsObservedOnceAfterPreflight()
         {
             using var client = new NoSQLClient(new NoSQLConfig


### PR DESCRIPTION
## Summary
- Adds query protocol V6 support and retains negotiated fallback through V5, V4, and V3.
- Deserializes V5/V6 query-plan fields and iterator opcodes, including UNION plans.
- Adds UNION execution, plan formatting, validation, and prepared-statement branch handling.
- Adds focused regression coverage for V6 version fallback, UNION branch metadata, and array-collect regrouping.

## Java Compatibility
Validated against Oracle NoSQL Database KV 26.3.6 built from current Bitbucket main at commit 858de2ff58df, with matching HTTP proxy main_26.3.B85.

A direct and prepared UNION ALL query both returned the expected rows on .NET 8, .NET 9, and .NET 10.

## Validation
- Complete SDK test project: 3,678 passed, 174 expected on-premise skips, 0 failures on each of net8.0, net9.0, and net10.0.
- Smoke workflow passed on net8.0, net9.0, and net10.0.
- Release SDK solution build passed with 0 warnings and 0 errors.
- Stats full-flow validation completed with 0 operation errors.
- KVLite and proxy remained healthy with no server or proxy log errors.

Addresses KVSTORE-3615.